### PR TITLE
Handle response headers better

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -35,12 +35,10 @@ func (c *Client) GetGameAnalytics(gameID string) (*GameAnalyticsResponse, error)
 
 	users := &GameAnalyticsResponse{}
 	users.StatusCode = resp.StatusCode
+	users.Header = resp.Header
 	users.Error = resp.Error
 	users.ErrorStatus = resp.ErrorStatus
 	users.ErrorMessage = resp.ErrorMessage
-	users.RateLimit.Limit = resp.RateLimit.Limit
-	users.RateLimit.Remaining = resp.RateLimit.Remaining
-	users.RateLimit.Reset = resp.RateLimit.Reset
 	users.Data.GameAnalytics = resp.Data.(*ManyGameAnalytics).GameAnalytics
 
 	return users, nil

--- a/bits.go
+++ b/bits.go
@@ -48,12 +48,10 @@ func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams) (*BitsLeaderb
 
 	bits := &BitsLeaderboardResponse{}
 	bits.StatusCode = resp.StatusCode
+	bits.Header = resp.Header
 	bits.Error = resp.Error
 	bits.ErrorStatus = resp.ErrorStatus
 	bits.ErrorMessage = resp.ErrorMessage
-	bits.RateLimit.Limit = resp.RateLimit.Limit
-	bits.RateLimit.Remaining = resp.RateLimit.Remaining
-	bits.RateLimit.Reset = resp.RateLimit.Reset
 	bits.Data.Total = resp.Data.(*ManyUserBitTotals).Total
 	bits.Data.DateRange = resp.Data.(*ManyUserBitTotals).DateRange
 	bits.Data.UserBitTotals = resp.Data.(*ManyUserBitTotals).UserBitTotals

--- a/clips.go
+++ b/clips.go
@@ -41,21 +41,13 @@ func (c *Client) GetClips(params *ClipsParams) (*ClipsResponse, error) {
 
 	clips := &ClipsResponse{}
 	clips.StatusCode = resp.StatusCode
+	clips.Header = resp.Header
 	clips.Error = resp.Error
 	clips.ErrorStatus = resp.ErrorStatus
 	clips.ErrorMessage = resp.ErrorMessage
-	clips.RateLimit.Limit = resp.RateLimit.Limit
-	clips.RateLimit.Remaining = resp.RateLimit.Remaining
-	clips.RateLimit.Reset = resp.RateLimit.Reset
 	clips.Data.Clips = resp.Data.(*ManyClips).Clips
 
 	return clips, nil
-}
-
-// ClipsCreationRateLimit ...
-type ClipsCreationRateLimit struct {
-	Limit     int
-	Remaining int
 }
 
 // ClipEditURL ...
@@ -101,14 +93,10 @@ func (c *Client) CreateClip(broadcasterID string) (*CreateClipResponse, error) {
 
 	clips := &CreateClipResponse{}
 	clips.StatusCode = resp.StatusCode
+	clips.Header = resp.Header
 	clips.Error = resp.Error
 	clips.ErrorStatus = resp.ErrorStatus
 	clips.ErrorMessage = resp.ErrorMessage
-	clips.RateLimit.Limit = resp.RateLimit.Limit
-	clips.RateLimit.Remaining = resp.RateLimit.Remaining
-	clips.RateLimit.Reset = resp.RateLimit.Reset
-	clips.ClipsCreationRateLimit.Limit = resp.ClipsCreationRateLimit.Limit
-	clips.ClipsCreationRateLimit.Remaining = resp.ClipsCreationRateLimit.Remaining
 	clips.Data.ClipEditURLs = resp.Data.(*ManyClipEditURLs).ClipEditURLs
 
 	return clips, nil

--- a/clips.go
+++ b/clips.go
@@ -67,11 +67,21 @@ type CreateClipResponse struct {
 	Data ManyClipEditURLs
 }
 
+// GetClipsCreationRateLimit returns the "Ratelimit-Helixclipscreation-Limit"
+// header as an int.
+func (ccr *CreateClipResponse) GetClipsCreationRateLimit() int {
+	return ccr.convertHeaderToInt(ccr.Header.Get("Ratelimit-Helixclipscreation-Limit"))
+}
+
+// GetClipsCreationRateLimitRemaining returns the "Ratelimit-Helixclipscreation-Remaining"
+// header as an int.
+func (ccr *CreateClipResponse) GetClipsCreationRateLimitRemaining() int {
+	return ccr.convertHeaderToInt(ccr.Header.Get("Ratelimit-Helixclipscreation-Remaining"))
+}
+
 type createClipRequestParams struct {
 	BroadcasterID string `query:"broadcaster_id"`
 }
-
-const createClipEndpoint = "/clips"
 
 // CreateClip creates a clip programmatically. This returns both an ID and
 // an edit URL for the new clip. Clip creation takes time. We recommend that
@@ -86,7 +96,7 @@ func (c *Client) CreateClip(broadcasterID string) (*CreateClipResponse, error) {
 		BroadcasterID: broadcasterID,
 	}
 
-	resp, err := c.post(createClipEndpoint, &ManyClipEditURLs{}, params)
+	resp, err := c.post("/clips", &ManyClipEditURLs{}, params)
 	if err != nil {
 		return nil, err
 	}

--- a/clips_test.go
+++ b/clips_test.go
@@ -2,7 +2,6 @@ package helix
 
 import (
 	"net/http"
-	"strconv"
 	"testing"
 )
 
@@ -73,31 +72,31 @@ func TestCreateClip(t *testing.T) {
 		options         *Options
 		broadcasterID   string
 		respBody        string
-		headerLimit     int
-		headerRemaining int
+		headerLimit     string
+		headerRemaining string
 	}{
 		{
 			http.StatusAccepted,
 			&Options{ClientID: "my-client-id"},
 			"26490481", // summit1g
 			`{"data":[{"id":"IronicHedonisticOryxSquadGoals","edit_url":"https://clips.twitch.tv/IronicHedonisticOryxSquadGoals/edit"}]}`,
-			600,
-			598,
+			"600",
+			"598",
 		},
 		{
 			http.StatusUnauthorized,
 			&Options{ClientID: "my-client-id"},
 			"26490481", // summit1g
 			`{"error":"Unauthorized","status":401,"message":"Missing clips:edit scope"}`, // missing required scope
-			600,
-			597,
+			"600",
+			"597",
 		},
 	}
 
 	for _, testCase := range testCases {
 		mockRespHeaders := map[string]string{
-			"Ratelimit-Helixclipscreation-Limit":     strconv.Itoa(testCase.headerLimit),
-			"Ratelimit-Helixclipscreation-Remaining": strconv.Itoa(testCase.headerRemaining),
+			"Ratelimit-Helixclipscreation-Limit":     testCase.headerLimit,
+			"Ratelimit-Helixclipscreation-Remaining": testCase.headerRemaining,
 		}
 
 		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, mockRespHeaders))
@@ -135,12 +134,12 @@ func TestCreateClip(t *testing.T) {
 			t.Errorf("expected clip edit url not to be empty, got \"%s\"", resp.Data.ClipEditURLs[0].EditURL)
 		}
 
-		if resp.ClipsCreationRateLimit.Limit < 1 {
-			t.Errorf("expected clip create rate limit limit not to be \"0\", got \"%d\"", resp.ClipsCreationRateLimit.Limit)
+		if resp.GetClipsCreationRateLimit() < 1 {
+			t.Errorf("expected clip create rate limit limit not to be \"0\", got \"%d\"", resp.GetClipsCreationRateLimit())
 		}
 
-		if resp.ClipsCreationRateLimit.Remaining < 1 {
-			t.Errorf("expected clip create rate limit remaining not to be \"0\", got \"%d\"", resp.ClipsCreationRateLimit.Remaining)
+		if resp.GetClipsCreationRateLimitRemaining() < 1 {
+			t.Errorf("expected clip create rate limit remaining not to be \"0\", got \"%d\"", resp.GetClipsCreationRateLimitRemaining())
 		}
 	}
 }

--- a/entitlement_grants.go
+++ b/entitlement_grants.go
@@ -38,12 +38,10 @@ func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string)
 
 	url := &EntitlementsUploadResponse{}
 	url.StatusCode = resp.StatusCode
+	url.Header = resp.Header
 	url.Error = resp.Error
 	url.ErrorStatus = resp.ErrorStatus
 	url.ErrorMessage = resp.ErrorMessage
-	url.RateLimit.Limit = resp.RateLimit.Limit
-	url.RateLimit.Remaining = resp.RateLimit.Remaining
-	url.RateLimit.Reset = resp.RateLimit.Reset
 	url.Data.URLs = resp.Data.(*ManyEntitlementsUploadURLs).URLs
 
 	return url, nil

--- a/games.go
+++ b/games.go
@@ -33,12 +33,10 @@ func (c *Client) GetGames(params *GamesParams) (*GamesResponse, error) {
 
 	games := &GamesResponse{}
 	games.StatusCode = resp.StatusCode
+	games.Header = resp.Header
 	games.Error = resp.Error
 	games.ErrorStatus = resp.ErrorStatus
 	games.ErrorMessage = resp.ErrorMessage
-	games.RateLimit.Limit = resp.RateLimit.Limit
-	games.RateLimit.Remaining = resp.RateLimit.Remaining
-	games.RateLimit.Reset = resp.RateLimit.Reset
 	games.Data.Games = resp.Data.(*ManyGames).Games
 
 	return games, nil
@@ -72,12 +70,10 @@ func (c *Client) GetTopGames(params *TopGamesParams) (*TopGamesResponse, error) 
 
 	games := &TopGamesResponse{}
 	games.StatusCode = resp.StatusCode
+	games.Header = resp.Header
 	games.Error = resp.Error
 	games.ErrorStatus = resp.ErrorStatus
 	games.ErrorMessage = resp.ErrorMessage
-	games.RateLimit.Limit = resp.RateLimit.Limit
-	games.RateLimit.Remaining = resp.RateLimit.Remaining
-	games.RateLimit.Reset = resp.RateLimit.Reset
 	games.Data.Games = resp.Data.(*ManyGamesWithPagination).Games
 	games.Data.Pagination = resp.Data.(*ManyGamesWithPagination).Pagination
 

--- a/helix.go
+++ b/helix.go
@@ -101,8 +101,8 @@ type Pagination struct {
 	Cursor string `json:"cursor"`
 }
 
-// NewClient returns a new Twicth Helix API client. It panics if
-// clientID is an empty string. It is concurrecy safe.
+// NewClient returns a new Twicth Helix API client. It returns an
+// if clientID is an empty string. It is concurrecy safe.
 func NewClient(options *Options) (*Client, error) {
 	if options.ClientID == "" {
 		return nil, errors.New("A client ID was not provided but is required")

--- a/helix.go
+++ b/helix.go
@@ -69,6 +69,27 @@ type ResponseCommon struct {
 	ErrorMessage string `json:"message"`
 }
 
+func (rc *ResponseCommon) convertHeaderToInt(str string) int {
+	i, _ := strconv.Atoi(str)
+
+	return i
+}
+
+// GetRateLimit returns the "RateLimit-Limit" header as an int.
+func (rc *ResponseCommon) GetRateLimit() int {
+	return rc.convertHeaderToInt(rc.Header.Get("RateLimit-Limit"))
+}
+
+// GetRateLimitRemaining returns the "RateLimit-Remaining" header as an int.
+func (rc *ResponseCommon) GetRateLimitRemaining() int {
+	return rc.convertHeaderToInt(rc.Header.Get("RateLimit-Remaining"))
+}
+
+// GetRateLimitReset returns the "RateLimit-Reset" header as an int.
+func (rc *ResponseCommon) GetRateLimitReset() int {
+	return rc.convertHeaderToInt(rc.Header.Get("RateLimit-Reset"))
+}
+
 // Response ...
 type Response struct {
 	ResponseCommon

--- a/streams.go
+++ b/streams.go
@@ -50,12 +50,10 @@ func (c *Client) GetStreams(params *StreamsParams) (*StreamsResponse, error) {
 
 	streams := &StreamsResponse{}
 	streams.StatusCode = resp.StatusCode
+	streams.Header = resp.Header
 	streams.Error = resp.Error
 	streams.ErrorStatus = resp.ErrorStatus
 	streams.ErrorMessage = resp.ErrorMessage
-	streams.RateLimit.Limit = resp.RateLimit.Limit
-	streams.RateLimit.Remaining = resp.RateLimit.Remaining
-	streams.RateLimit.Reset = resp.RateLimit.Reset
 	streams.Data.Streams = resp.Data.(*ManyStreams).Streams
 	streams.Data.Pagination = resp.Data.(*ManyStreams).Pagination
 
@@ -117,34 +115,22 @@ type StreamsMetadataResponse struct {
 	Data ManyStreamsMetadata
 }
 
-// StreamsMetadataRateLimit ...
-type StreamsMetadataRateLimit struct {
-	Limit     int
-	Remaining int
-}
-
 // StreamsMetadataParams ...
 type StreamsMetadataParams StreamsParams
 
-const streamsMetadataEndpoint = "/streams/metadata"
-
 // GetStreamsMetadata ...
 func (c *Client) GetStreamsMetadata(params *StreamsMetadataParams) (*StreamsMetadataResponse, error) {
-	resp, err := c.get(streamsMetadataEndpoint, &ManyStreamsMetadata{}, params)
+	resp, err := c.get("/streams/metadata", &ManyStreamsMetadata{}, params)
 	if err != nil {
 		return nil, err
 	}
 
 	streams := &StreamsMetadataResponse{}
 	streams.StatusCode = resp.StatusCode
+	streams.Header = resp.Header
 	streams.Error = resp.Error
 	streams.ErrorStatus = resp.ErrorStatus
 	streams.ErrorMessage = resp.ErrorMessage
-	streams.RateLimit.Limit = resp.RateLimit.Limit
-	streams.RateLimit.Remaining = resp.RateLimit.Remaining
-	streams.RateLimit.Reset = resp.RateLimit.Reset
-	streams.StreamsMetadataRateLimit.Limit = resp.StreamsMetadataRateLimit.Limit
-	streams.StreamsMetadataRateLimit.Remaining = resp.StreamsMetadataRateLimit.Remaining
 	streams.Data.Streams = resp.Data.(*ManyStreamsMetadata).Streams
 	streams.Data.Pagination = resp.Data.(*ManyStreamsMetadata).Pagination
 

--- a/streams.go
+++ b/streams.go
@@ -115,6 +115,18 @@ type StreamsMetadataResponse struct {
 	Data ManyStreamsMetadata
 }
 
+// GetStreamsMetadataRateLimit returns the "Ratelimit-Helixstreamsmetadata-Limit"
+// header as an int.
+func (sr *StreamsMetadataResponse) GetStreamsMetadataRateLimit() int {
+	return sr.convertHeaderToInt(sr.Header.Get("Ratelimit-Helixstreamsmetadata-Limit"))
+}
+
+// GetStreamsMetadataRateLimitRemaining returns the "Ratelimit-Helixstreamsmetadata-Remaining"
+// header as an int.
+func (sr *StreamsMetadataResponse) GetStreamsMetadataRateLimitRemaining() int {
+	return sr.convertHeaderToInt(sr.Header.Get("Ratelimit-Helixstreamsmetadata-Remaining"))
+}
+
 // StreamsMetadataParams ...
 type StreamsMetadataParams StreamsParams
 

--- a/streams_test.go
+++ b/streams_test.go
@@ -68,8 +68,8 @@ func TestGetStreamsMetadata(t *testing.T) {
 		respBody            string
 		expectBroadcastHero []string
 		expectOpponentHero  []string
-		headerLimit         int
-		headerRemaining     int
+		headerLimit         string
+		headerRemaining     string
 	}{
 		{
 			http.StatusOK,
@@ -78,8 +78,8 @@ func TestGetStreamsMetadata(t *testing.T) {
 			`{"data":[{"user_id":"43356746","game_id":"138585","overwatch":null,"hearthstone":{"broadcaster":{"hero":{"type":"Alternate hero","class":"Mage","name":"Medivh"}},"opponent":{"hero":{"type":"Classic hero","class":"Warlock","name":"Guldan"}}}}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MX19"}}`,
 			[]string{"Alternate hero", "Mage", "Medivh"},  // type, class, name
 			[]string{"Classic hero", "Warlock", "Guldan"}, // type, class, name
-			15000,
-			14119,
+			"15000",
+			"14119",
 		},
 		{
 			http.StatusOK,
@@ -88,8 +88,8 @@ func TestGetStreamsMetadata(t *testing.T) {
 			`{"data":[{"user_id":"132395117","game_id":"488552","overwatch":{"broadcaster":{"hero":{"role":"Support","name":"Lucio","ability":"Sonic Amplifier"}}},"hearthstone":null}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MX19"}}`,
 			[]string{"Support", "Lucio", "Sonic Amplifier"}, // role, name, ability
 			[]string{}, // N/A
-			15000,
-			14119,
+			"15000",
+			"14119",
 		},
 		{
 			http.StatusBadRequest,
@@ -98,15 +98,15 @@ func TestGetStreamsMetadata(t *testing.T) {
 			`{"error":"Bad Request","status":400,"message":"The parameter \"first\" was malformed: the value must be less than or equal to 100"}`,
 			[]string{}, // N/A
 			[]string{}, // N/A
-			0,
-			0,
+			"0",
+			"0",
 		},
 	}
 
 	for _, testCase := range testCases {
 		mockRespHeaders := map[string]string{
-			"Ratelimit-Helixstreamsmetadata-Limit":     strconv.Itoa(testCase.headerLimit),
-			"Ratelimit-Helixstreamsmetadata-Remaining": strconv.Itoa(testCase.headerRemaining),
+			"Ratelimit-Helixstreamsmetadata-Limit":     testCase.headerLimit,
+			"Ratelimit-Helixstreamsmetadata-Remaining": testCase.headerRemaining,
 		}
 
 		mockHandler := newMockHandler(testCase.statusCode, testCase.respBody, mockRespHeaders)
@@ -124,11 +124,13 @@ func TestGetStreamsMetadata(t *testing.T) {
 		}
 
 		// Test metadata headers response
-		if resp.StreamsMetadataRateLimit.Limit != testCase.headerLimit {
-			t.Errorf("expected metadata limit header to be \"%d\", got \"%d\"", testCase.headerLimit, resp.StreamsMetadataRateLimit.Limit)
+		headerLimit, _ := strconv.Atoi(testCase.headerLimit)
+		if resp.GetStreamsMetadataRateLimit() != headerLimit {
+			t.Errorf("expected metadata limit header to be \"%d\", got \"%d\"", headerLimit, resp.GetStreamsMetadataRateLimit())
 		}
-		if resp.StreamsMetadataRateLimit.Remaining != testCase.headerRemaining {
-			t.Errorf("expected metadata remaining header to be \"%d\", got \"%d\"", testCase.headerRemaining, resp.StreamsMetadataRateLimit.Remaining)
+		headerRemaining, _ := strconv.Atoi(testCase.headerRemaining)
+		if resp.GetStreamsMetadataRateLimitRemaining() != headerRemaining {
+			t.Errorf("expected metadata remaining header to be \"%d\", got \"%d\"", headerRemaining, resp.GetStreamsMetadataRateLimitRemaining())
 		}
 
 		// Test Bad Request Responses

--- a/users.go
+++ b/users.go
@@ -42,12 +42,10 @@ func (c *Client) GetUsers(params *UsersParams) (*UsersResponse, error) {
 
 	users := &UsersResponse{}
 	users.StatusCode = resp.StatusCode
+	users.Header = resp.Header
 	users.Error = resp.Error
 	users.ErrorStatus = resp.ErrorStatus
 	users.ErrorMessage = resp.ErrorMessage
-	users.RateLimit.Limit = resp.RateLimit.Limit
-	users.RateLimit.Remaining = resp.RateLimit.Remaining
-	users.RateLimit.Reset = resp.RateLimit.Reset
 	users.Data.Users = resp.Data.(*ManyUsers).Users
 
 	return users, nil
@@ -73,12 +71,10 @@ func (c *Client) UpdateUser(description string) (*UsersResponse, error) {
 
 	users := &UsersResponse{}
 	users.StatusCode = resp.StatusCode
+	users.Header = resp.Header
 	users.Error = resp.Error
 	users.ErrorStatus = resp.ErrorStatus
 	users.ErrorMessage = resp.ErrorMessage
-	users.RateLimit.Limit = resp.RateLimit.Limit
-	users.RateLimit.Remaining = resp.RateLimit.Remaining
-	users.RateLimit.Reset = resp.RateLimit.Reset
 	users.Data.Users = resp.Data.(*ManyUsers).Users
 
 	return users, nil
@@ -125,12 +121,10 @@ func (c *Client) GetUsersFollows(params *UsersFollowsParams) (*UsersFollowsRespo
 
 	users := &UsersFollowsResponse{}
 	users.StatusCode = resp.StatusCode
+	users.Header = resp.Header
 	users.Error = resp.Error
 	users.ErrorStatus = resp.ErrorStatus
 	users.ErrorMessage = resp.ErrorMessage
-	users.RateLimit.Limit = resp.RateLimit.Limit
-	users.RateLimit.Remaining = resp.RateLimit.Remaining
-	users.RateLimit.Reset = resp.RateLimit.Reset
 	users.Data.Total = resp.Data.(*ManyFollows).Total
 	users.Data.Follows = resp.Data.(*ManyFollows).Follows
 	users.Data.Pagination = resp.Data.(*ManyFollows).Pagination

--- a/videos.go
+++ b/videos.go
@@ -53,12 +53,10 @@ func (c *Client) GetVideos(params *VideosParams) (*VideosResponse, error) {
 
 	videos := &VideosResponse{}
 	videos.StatusCode = resp.StatusCode
+	videos.Header = resp.Header
 	videos.Error = resp.Error
 	videos.ErrorStatus = resp.ErrorStatus
 	videos.ErrorMessage = resp.ErrorMessage
-	videos.RateLimit.Limit = resp.RateLimit.Limit
-	videos.RateLimit.Remaining = resp.RateLimit.Remaining
-	videos.RateLimit.Reset = resp.RateLimit.Reset
 	videos.Data.Videos = resp.Data.(*ManyVideos).Videos
 	videos.Data.Pagination = resp.Data.(*ManyVideos).Pagination
 


### PR DESCRIPTION
This PR introduces breaking changes. All changes include:

- Replace all hard-code response rate limit headers with a more generic http.Header approach. This means that all headers can now be accessed using Go's built-in header methods. For example: `resp.Header.Get("Ratelimit-Limit")` or `resp.Header.Get("WWW-Authenticate")`
- Using `resp.RateLimit.Limit` to retrieve these header values as integers has been removed. These have been replaced with the following methods:
  - `resp.GetRateLimit()`
  - `resp.GetRateLimitRemaining()`
  - `resp.GetRateLimitReset()`
  - `resp.GetClipsCreationRateLimit()` (only available when called `client.CreateClip()`)
  - `resp.GetClipsCreationRateLimitRemaining()` (only available when called `client.CreateClip()`)
  - `resp.GetStreamsMetadataRateLimit()` (only available when called `client.GetStreamsMetadata()`)
  - `resp.GetStreamsMetadataRateLimitRemaining()` (only available when called `client.GetStreamsMetadata()`)
- Added addition test for covering core HTTP client request error responses.

<br>

TODO:

- [x] Increase test coverage

<br>

Closes #4 