### PR TITLE
Add client.GetStreamMarkers(..)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ PRs are very much welcome. Where possible, please write tests for any code that 
 Thanks to all of the following people (ordered alphabetically) for contributing their time for improving this library:
 
 - Y.Horie ([@u5surf](https://github.com/u5surf))
+- Philipp Führer ([@flipkick](https://github.com/flipkick))
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All documentation and usage examples for this package can be found in the [docs 
 - [x] Get Game Analytics
 - [x] Get Streams
 - [x] Get Streams Metadata
+- [x] Get Stream Markers
 - [x] Get Users
 - [x] Get Users Follows
 - [x] Update User

--- a/docs/stream_markers_docs.md
+++ b/docs/stream_markers_docs.md
@@ -1,0 +1,29 @@
+# Stream Markers Documentation
+
+## Get Stream Markers
+
+This is an example of how to get stream markers. You can request the stream markers of
+a VOD or a livestream of an user if it is recorded as VOD as well. Here we are
+requesting the first two stream markers of a VOD. The authenticated user requires the
+`user:read:broadcast` scope to be able to request stream markers of this user.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID:        "your-client-id",
+    UserAccessToken: "your-user-access-token",
+})
+
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetStreamMarkers(&helix.StreamMarkersParams{
+    First: 2,
+    VideoID: "123",
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```

--- a/stream_markers.go
+++ b/stream_markers.go
@@ -1,0 +1,97 @@
+package helix
+
+import (
+	"time"
+)
+
+// StreamMarkerAPIDetails ...
+type StreamMarkerAPIDetails struct {
+	ID              string    `json:"id"`
+	CreatedAt       time.Time `json:"created_at"`
+	Description     string    `json:"description"`
+	PositionSeconds int       `json:"position_seconds"`
+	URL             string    `json:"URL"`
+}
+
+// StreamMarkerAPIVideo ...
+type StreamMarkerAPIVideo struct {
+	VideoID string                   `json:"video_id"`
+	Markers []StreamMarkerAPIDetails `json:"markers"`
+}
+
+// StreamMarkersAPIResponseData ...
+type StreamMarkersAPIResponseData struct {
+	UserID   string                 `json:"user_id"`
+	UserName string                 `json:"user_name"`
+	Videos   []StreamMarkerAPIVideo `json:"videos"`
+}
+
+// StreamMarkersAPIResponse ...
+type StreamMarkersAPIResponse struct {
+	Data       []StreamMarkersAPIResponseData `json:"data"`
+	Pagination Pagination                     `json:"pagination"`
+}
+
+// StreamMarkersResponseData ...
+type StreamMarkersResponseData struct {
+	UserID   string                   `json:"user_id"`
+	UserName string                   `json:"user_name"`
+	VideoID  string                   `json:"video_id"`
+	Markers  []StreamMarkerAPIDetails `json:"markers"`
+}
+
+// StreamMarkersResponse ...
+type StreamMarkersResponse struct {
+	ResponseCommon
+
+	Data       StreamMarkersResponseData
+	Pagination Pagination `json:"pagination"`
+}
+
+// StreamMarkersParams requires _either_ UserID or VideoID set
+//
+// UserID: fetches stream markers of the current livestream of the given user
+// (VOD recording must be enabled).
+// VideoID: fetches streams markers of the VOD.
+type StreamMarkersParams struct {
+	UserID  string `query:"user_id"`
+	VideoID string `query:"video_id"`
+
+	// Optional
+	After  string `query:"after"`
+	Before string `query:"before"`
+	First  int    `query:"first,20"` // Limit 100
+}
+
+// GetStreamMarkers gets stream markers of a VOD or of the current live stream
+// of an user being recorded as VOD.
+//
+// Required Scope: user:read:broadcast
+func (c *Client) GetStreamMarkers(params *StreamMarkersParams) (*StreamMarkersResponse, error) {
+	apiResponse := &StreamMarkersAPIResponse{}
+	resp, err := c.get("/streams/markers", apiResponse, params)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData := StreamMarkersResponseData{}
+	if len(apiResponse.Data) > 0 {
+		responseData.UserID = apiResponse.Data[0].UserID
+		responseData.UserName = apiResponse.Data[0].UserName
+		responseData.VideoID = apiResponse.Data[0].Videos[0].VideoID
+		responseData.Markers = apiResponse.Data[0].Videos[0].Markers
+	}
+
+	streamMarkers := &StreamMarkersResponse{
+		Data: responseData,
+		ResponseCommon: ResponseCommon{
+			StatusCode:   resp.StatusCode,
+			Header:       resp.Header,
+			Error:        resp.Error,
+			ErrorStatus:  resp.ErrorStatus,
+			ErrorMessage: resp.ErrorMessage,
+		},
+	}
+
+	return streamMarkers, nil
+}

--- a/stream_markers_test.go
+++ b/stream_markers_test.go
@@ -1,0 +1,65 @@
+package helix
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetStreamMarkers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode  int
+		options     *Options
+		userID      string
+		markerCount int
+		first       int
+		respBody    string
+	}{
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			"123",
+			1,
+			5,
+			`{"data":[{"user_id":"123","user_name":"DisplayName","videos":[{"video_id":"456","markers":[{"id":"106b8d6243a4f883d25ad75e6cdffdc4","created_at":"2018-08-20T20:10:03Z","description":"hello,thisisamarker!","position_seconds":244,"URL":"https://twitch.tv/videos/456?t=0h4m06s"}]}]}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjoiMjk1MjA0Mzk3OjI1Mzpib29rbWFyazoxMDZiOGQ1Y"}}`,
+		},
+		{
+			http.StatusBadRequest,
+			&Options{ClientID: "my-client-id"},
+			"0",
+			0,
+			101,
+			`{"error":"Bad Request","status":400,"message":"The parameter \"first\" was malformed: the value must be less than or equal to 100"}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.GetStreamMarkers(&StreamMarkersParams{
+			UserID: testCase.userID,
+			First:  testCase.first,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Test Bad Request Responses
+		if resp.StatusCode == http.StatusBadRequest {
+			firstErrStr := "The parameter \"first\" was malformed: the value must be less than or equal to 100"
+			if resp.ErrorMessage != firstErrStr {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", firstErrStr, resp.ErrorMessage)
+			}
+			continue
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		if len(resp.Data.Markers) != testCase.markerCount {
+			t.Errorf("expected \"%d\" streams, got \"%d\"", testCase.markerCount, len(resp.Data.Markers))
+		}
+	}
+}

--- a/stream_markers_test.go
+++ b/stream_markers_test.go
@@ -22,8 +22,7 @@ func TestGetStreamMarkers(t *testing.T) {
 			"123",
 			1,
 			5,
-			`{"data":[{"user_id":"123","user_name":"DisplayName","videos":[{"video_id":"456","markers":[{"id":"106b8d6243a4f883d25ad75e6cdffdc4","created_at":"2018-08-20T20:10:03Z","description":"hello,thisisamarker!","position_seconds":244,"URL":"https://twitch.tv/videos/456?t=0h4m06s"}]}]}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjoiMjk1MjA0Mzk3OjI1Mzpib29rbWFyazoxMDZiOGQ1Y"}}`,
-		},
+			`{"data":[{"user_id":"123","user_name":"DisplayName","videos":[{"video_id":"456","markers":[{"id":"106b8d6243a4f883d25ad75e6cdffdc4","created_at":"2018-08-20T20:10:03Z","description":"hello,thisisamarker!","position_seconds":244,"URL":"https://twitch.tv/videos/456?t=0h4m06s"}]}]}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjoiMjk1MjA0Mzk3OjI1Mzpib29rbWFyazoxMDZiOGQ1Y"}}`},
 		{
 			http.StatusBadRequest,
 			&Options{ClientID: "my-client-id"},
@@ -58,8 +57,8 @@ func TestGetStreamMarkers(t *testing.T) {
 			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
 		}
 
-		if len(resp.Data.Markers) != testCase.markerCount {
-			t.Errorf("expected \"%d\" streams, got \"%d\"", testCase.markerCount, len(resp.Data.Markers))
+		if len(resp.Data.StreamMarkers[0].Videos[0].Markers) != testCase.markerCount {
+			t.Errorf("expected \"%d\" stream markers, got \"%d\"", testCase.markerCount, len(resp.Data.StreamMarkers))
 		}
 	}
 }


### PR DESCRIPTION
Get Stream Markers API Endpoint. 

The API is really strange when it comes to Get Stream Markers. The example response from the API docs looks like this:

```{
  "data": [
    {
      "user_id": "123",
      "user_name": "Display Name",
      "videos": [
        {
          "video_id": "456",
          "markers": [
            {
              "id": "106b8d6243a4f883d25ad75e6cdffdc4",
              "created_at": "2018-08-20T20:10:03Z",
              "description": "hello, this is a marker!",
              "position_seconds": 244,
              "URL": "https://twitch.tv/videos/456?t=0h4m06s"
            },
            ...
          ]
        }
      ]
    }
  ],
  "pagination": {
    "cursor": "eyJiIjpudWxsLCJhIjoiMjk1MjA0Mzk3OjI1Mzpib29rbWFyazoxMDZiOGQ1Y"
  }
}
```

So you will always get a data array of size 0 or 1. If there is an element, it returns another array "videos" which always has a size of 1. In this array you find another array "markers" which has always the size 1 or larger. To use this API directly, in helix it would look like: 
```
resp, _ := client.GetStreamMarkers(..)
fmt.Println(resp.Data.Data[0].Videos[0].Markers[0].Description)
```

To avoid this nested hell, I've implemented a custom StreamMarkersResponse which returns a cleaner structure:

```
resp, _ := client.GetStreamMarkers(..)
fmt.Println(resp.Data.VideoID)
fmt.Println(resp.Data.Markers[0].Description)
```
