### PR TITLE
Add support for subscribing/unsubscribing to/from webhook events

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -1,6 +1,7 @@
 package helix
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -223,19 +224,50 @@ func isZero(v interface{}) (bool, error) {
 func (c *Client) newRequest(method, path string, data interface{}) (*http.Request, error) {
 	url := c.getBaseURL(path) + path
 
+	// We want to send Webhook POST request data in JSON form.
+	// So here we determine if data is of type `WebhookSubscriptionPayload`.
+	_, ok := data.(*WebhookSubscriptionPayload)
+	if ok {
+		return c.newJSONRequest(method, url, data)
+	}
+
+	return c.newStandardRequest(method, url, data)
+}
+
+func (c *Client) newStandardRequest(method, url string, data interface{}) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if data != nil {
-		query, err := buildQueryString(req, data)
-		if err != nil {
-			return nil, err
-		}
-
-		req.URL.RawQuery = query
+	if data == nil {
+		return req, nil
 	}
+
+	query, err := buildQueryString(req, data)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.RawQuery = query
+
+	return req, nil
+}
+
+func (c *Client) newJSONRequest(method, url string, data interface{}) (*http.Request, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(b)
+
+	req, err := http.NewRequest(method, url, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	return req, nil
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -27,7 +27,7 @@ type WebhookSubscriptionsParams struct {
 }
 
 // GetWebhookSubscriptions gets webhook subscriptions, in order of expiration.
-// Require app access token.
+// Requires an app access token.
 func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams) (*WebhookSubscriptionsResponse, error) {
 	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params)
 	if err != nil {
@@ -45,4 +45,35 @@ func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams) (*W
 	webhooks.Data.Pagination = resp.Data.(*ManyWebhookSubscriptions).Pagination
 
 	return webhooks, nil
+}
+
+// WebhookSubscriptionResponse ...
+type WebhookSubscriptionResponse struct {
+	ResponseCommon
+}
+
+// WebhookSubscriptionPayload ...
+type WebhookSubscriptionPayload struct {
+	Mode         string `json:"hub.mode"`
+	Topic        string `json:"hub.topic"`
+	Callback     string `json:"hub.callback"`
+	LeaseSeconds int    `json:"hub.lease_seconds,omitempty"`
+	Secret       string `json:"secret,omitempty"`
+}
+
+// PostWebhookSubscription ...
+func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload) (*WebhookSubscriptionResponse, error) {
+	resp, err := c.post("/webhooks/hub", nil, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	webhook := &WebhookSubscriptionResponse{}
+	webhook.StatusCode = resp.StatusCode
+	webhook.Header = resp.Header
+	webhook.Error = resp.Error
+	webhook.ErrorStatus = resp.ErrorStatus
+	webhook.ErrorMessage = resp.ErrorMessage
+
+	return webhook, nil
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -1,5 +1,10 @@
 package helix
 
+import (
+	"net/http"
+	"regexp"
+)
+
 // WebhookSubscription ...
 type WebhookSubscription struct {
 	Topic     string `json:"topic"`
@@ -76,4 +81,117 @@ func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload) (*
 	webhook.ErrorMessage = resp.ErrorMessage
 
 	return webhook, nil
+}
+
+// Regular expressions used for parsing webhook link headers
+var (
+	UserFollowsRegexp        = regexp.MustCompile("helix/users/follows\\?first=1(&from_id=(?P<from_id>\\d+))?(&to_id=(?P<to_id>\\d+))?>")
+	StreamChangedRegexp      = regexp.MustCompile("helix/streams\\?user_id=(?P<user_id>\\d+)>")
+	UserChangedRegexp        = regexp.MustCompile("helix/users\\?id=(?P<id>\\d+)>")
+	GameAnalyticsRegexp      = regexp.MustCompile("helix/analytics\\?game_id=(?P<game_id>\\w+)>")
+	ExtensionAnalyticsRegexp = regexp.MustCompile("helix/analytics\\?extension_id=(?P<extension_id>\\w+)>")
+)
+
+// WebhookTopic is a topic that relates to a specific webhook event.
+type WebhookTopic int
+
+// Enumerated webhook topics
+const (
+	UserFollowsTopic WebhookTopic = iota
+	StreamChangedTopic
+	UserChangedTopic
+	GameAnalyticsTopic
+	ExtensionAnalyticsTopic
+)
+
+// GetWebhookTopicFromRequest inspects the "Link" request header to
+// determine if it matches against any recognised webhooks topics.
+// The matched topic is returned. Otherwise -1 is returned.
+func GetWebhookTopicFromRequest(req *http.Request) WebhookTopic {
+	header := getLinkHeaderFromWebhookRequest(req)
+
+	if UserFollowsRegexp.MatchString(header) {
+		return UserFollowsTopic
+	}
+	if StreamChangedRegexp.MatchString(header) {
+		return StreamChangedTopic
+	}
+	if UserChangedRegexp.MatchString(header) {
+		return UserChangedTopic
+	}
+	if GameAnalyticsRegexp.MatchString(header) {
+		return GameAnalyticsTopic
+	}
+	if ExtensionAnalyticsRegexp.MatchString(header) {
+		return ExtensionAnalyticsTopic
+	}
+
+	return -1
+}
+
+// GetWebhookTopicValuesFromRequest inspects the "Link" request header to
+// determine if it matches against any recognised webhooks topics and
+// returns the unique values specified in the header.
+//
+// For example, say we receive a "User Follows" webhook event from Twitch.
+// Its "Link" header value look likes the following:
+//
+// 		<https://api.twitch.tv/helix/webhooks/hub>; rel="hub", <https://api.twitch.tv/helix/users/follows?first=1&from_id=111116&to_id=22222>; rel="self"
+//
+// From which GetWebhookTopicValuesFromRequest will return a map with the
+// values of from_id and to_id:
+//
+// 		map[from_id:111116 to_id:22222]
+//
+// This is particularly useful for webhooks events that do not have a distinguishable
+// JSON payload, such as the "Stream Changed" down event.
+//
+// Additionally, if topic is not known you can pass -1 as its value and
+func GetWebhookTopicValuesFromRequest(req *http.Request, topic WebhookTopic) map[string]string {
+	values := make(map[string]string)
+	webhookTopic := topic
+	header := getLinkHeaderFromWebhookRequest(req)
+
+	// Webhook topic may not be known, so let's attempt to
+	// determine its value based on the request.
+	if webhookTopic < 0 && header != "" {
+		webhookTopic = GetWebhookTopicFromRequest(req)
+	}
+
+	switch webhookTopic {
+	case UserFollowsTopic:
+		values = findStringSubmatchMap(UserFollowsRegexp, header)
+	case StreamChangedTopic:
+		values = findStringSubmatchMap(StreamChangedRegexp, header)
+	case UserChangedTopic:
+		values = findStringSubmatchMap(UserChangedRegexp, header)
+	case GameAnalyticsTopic:
+		values = findStringSubmatchMap(GameAnalyticsRegexp, header)
+	case ExtensionAnalyticsTopic:
+		values = findStringSubmatchMap(ExtensionAnalyticsRegexp, header)
+	}
+
+	return values
+}
+
+func getLinkHeaderFromWebhookRequest(req *http.Request) string {
+	return req.Header.Get("link")
+}
+
+func findStringSubmatchMap(r *regexp.Regexp, s string) map[string]string {
+	captures := make(map[string]string)
+
+	match := r.FindStringSubmatch(s)
+	if match == nil {
+		return captures
+	}
+
+	for i, name := range r.SubexpNames() {
+		if i == 0 || name == "" {
+			continue
+		}
+		captures[name] = match[i]
+
+	}
+	return captures
 }

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -44,7 +44,7 @@ func TestGetWebhookSubscriptions(t *testing.T) {
 
 		if resp.StatusCode == http.StatusUnauthorized {
 			if resp.Error != "Unauthorized" {
-				t.Errorf("expected error to be \"%s\", got \"%s\"", "Bad Request", resp.Error)
+				t.Errorf("expected error to be \"%s\", got \"%s\"", "Unauthorized", resp.Error)
 			}
 
 			if resp.ErrorStatus != http.StatusUnauthorized {
@@ -61,6 +61,63 @@ func TestGetWebhookSubscriptions(t *testing.T) {
 
 		if len(resp.Data.WebhookSubscriptions) != testCase.First {
 			t.Errorf("expected result length to be \"%d\", got \"%d\"", testCase.First, len(resp.Data.WebhookSubscriptions))
+		}
+	}
+}
+
+func TestPostWebhookSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode int
+		options    *Options
+		respBody   string
+	}{
+		{
+			http.StatusAccepted,
+			&Options{ClientID: "my-client-id", AppAccessToken: "valid-app-access-token"},
+			"",
+		},
+		{
+			http.StatusUnauthorized,
+			&Options{ClientID: "my-client-id", AppAccessToken: "invalid-app-access-token"},
+			`{"error":"Unauthorized","status":401,"message":"Must provide valid app token."}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.PostWebhookSubscription(&WebhookSubscriptionPayload{
+			Callback:     "https://my.callback/url",
+			Mode:         "subscribe",
+			Topic:        "https://api.twitch.tv/helix/users/follows?first=1&from_id=1111&to_id=2222",
+			LeaseSeconds: 0,
+			Secret:       "53cr3t",
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized {
+			if resp.Error != "Unauthorized" {
+				t.Errorf("expected error to be \"%s\", got \"%s\"", "Unauthorized", resp.Error)
+			}
+
+			if resp.ErrorStatus != http.StatusUnauthorized {
+				t.Errorf("expected error status to be \"%d\", got \"%d\"", http.StatusUnauthorized, resp.ErrorStatus)
+			}
+
+			expectedErrMsg := "Must provide valid app token."
+			if resp.ErrorMessage != expectedErrMsg {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", expectedErrMsg, resp.ErrorMessage)
+			}
+
+			continue
 		}
 	}
 }

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -2,6 +2,7 @@ package helix
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -118,6 +119,136 @@ func TestPostWebhookSubscriptions(t *testing.T) {
 			}
 
 			continue
+		}
+	}
+}
+
+func newMockWebhookRequest(header string) *http.Request {
+	return &http.Request{Header: map[string][]string{"Link": []string{header}}}
+}
+
+func TestGetWebhookTopicFromRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		req   *http.Request
+		topic WebhookTopic
+	}{
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&from_id=1234&to_id=5678>; rel=\"self\""),
+			UserFollowsTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&from_id=1234>; rel=\"self\""),
+			UserFollowsTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&to_id=1234>; rel=\"self\""),
+			UserFollowsTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/streams?user_id=1234>; rel=\"self\""),
+			StreamChangedTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users?id=1234>; rel=\"self\""),
+			UserChangedTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/analytics?game_id=1a2b3c4d>; rel=\"self\""),
+			GameAnalyticsTopic,
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/analytics?extension_id=1a2b3c4d>; rel=\"self\""),
+			ExtensionAnalyticsTopic,
+		},
+		{
+			newMockWebhookRequest("bad header value"),
+			-1,
+		},
+		{
+			newMockWebhookRequest(""),
+			-1,
+		},
+		{
+			&http.Request{},
+			-1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		topic := GetWebhookTopicFromRequest(testCase.req)
+		if topic != testCase.topic {
+			t.Errorf("expected webhook topic to be \"%d\", got \"%d\"", testCase.topic, topic)
+		}
+	}
+}
+
+func TestGetWebhookTopicValuesFromRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		req    *http.Request
+		topic  WebhookTopic
+		values map[string]string
+	}{
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&from_id=1234&to_id=5678>; rel=\"self\""),
+			UserFollowsTopic,
+			map[string]string{"from_id": "1234", "to_id": "5678"},
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&from_id=1234>; rel=\"self\""),
+			UserFollowsTopic,
+			map[string]string{"from_id": "1234", "to_id": ""},
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users/follows?first=1&to_id=5678>; rel=\"self\""),
+			UserFollowsTopic,
+			map[string]string{"from_id": "", "to_id": "5678"},
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/streams?user_id=1234>; rel=\"self\""),
+			StreamChangedTopic,
+			map[string]string{"user_id": "1234"},
+		},
+
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/users?id=1234>; rel=\"self\""),
+			UserChangedTopic,
+			map[string]string{"id": "1234"},
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/analytics?game_id=1a2b3c4d>; rel=\"self\""),
+			GameAnalyticsTopic,
+			map[string]string{"game_id": "1a2b3c4d"},
+		},
+		{
+			newMockWebhookRequest("<https://api.twitch.tv/helix/webhooks/hub>; rel=\"hub\", <https://api.twitch.tv/helix/analytics?extension_id=1a2b3c4d>; rel=\"self\""),
+			ExtensionAnalyticsTopic,
+			map[string]string{"extension_id": "1a2b3c4d"},
+		},
+		{
+			newMockWebhookRequest("bad header value"),
+			-1,
+			make(map[string]string),
+		},
+		{
+			newMockWebhookRequest(""),
+			-1,
+			make(map[string]string),
+		},
+		{
+			&http.Request{},
+			-1,
+			make(map[string]string),
+		},
+	}
+
+	for _, testCase := range testCases {
+		values := GetWebhookTopicValuesFromRequest(testCase.req, testCase.topic)
+		if !reflect.DeepEqual(values, testCase.values) {
+			t.Errorf("expected webhook values to be \"%v\", got \"%v\"", testCase.values, values)
 		}
 	}
 }


### PR DESCRIPTION
This adds a new endpoint for subscribing/unsubscribing to Twitch webhook events. It also includes some convenience methods for identifying individual webhook events when received from Twitch.

TODO:
- [ ] Add docs