### PR TITLE
Fix date serialization in query parameters

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -186,17 +186,19 @@ func buildQueryString(req *http.Request, v interface{}) (string, error) {
 			// Get and correctly format datetime fields, and attach them query params
 			dateStr := fmt.Sprintf("%v", vValue.Field(i))
 
-			if strings.Contains(dateStr, " m=-") {
-				datetimeSplit := strings.Split(dateStr, " m=-")
-				date, err := time.Parse(requestDateTimeFormat, datetimeSplit[0])
-				if err != nil {
-					return "", err
-				}
+			if strings.Contains(dateStr, " m=") {
+				datetimeSplit := strings.Split(dateStr, " m=")
+				dateStr = datetimeSplit[0]
+			}
 
-				// Determine if the date has been set. If it has we'll add it to the query.
-				if !date.IsZero() {
-					query.Add(tag, date.Format(time.RFC3339))
-				}
+			date, err := time.Parse(requestDateTimeFormat, dateStr)
+			if err != nil {
+				return "", err
+			}
+
+			// Determine if the date has been set. If it has we'll add it to the query.
+			if !date.IsZero() {
+				query.Add(tag, date.Format(time.RFC3339))
 			}
 		} else {
 			// Add any scalar values as query params


### PR DESCRIPTION
Two issues are resolved in this patch:
1) Only dates which contained monotonic clock offsets could be serialized into query parameters
2) Only dates with negative monotonic clock offsets could be serialized into query parameters

This meant that absolute dates (such as those parsed from other API responses) could not be passed through to subsequent requests.