### PR TITLE
Replace CommunityIDs with TagIDs

### DIFF
--- a/streams.go
+++ b/streams.go
@@ -8,7 +8,7 @@ type Stream struct {
 	UserID       string    `json:"user_id"`
 	UserName     string    `json:"user_name"`
 	GameID       string    `json:"game_id"`
-	CommunityIDs []string  `json:"community_ids"`
+	TagIDs       []string  `json:"tag_ids"`
 	Type         string    `json:"type"`
 	Title        string    `json:"title"`
 	ViewerCount  int       `json:"viewer_count"`
@@ -31,15 +31,14 @@ type StreamsResponse struct {
 
 // StreamsParams ...
 type StreamsParams struct {
-	After        string   `query:"after"`
-	Before       string   `query:"before"`
-	CommunityIDs []string `query:"community_id"`
-	First        int      `query:"first,20"`   // Limit 100
-	GameIDs      []string `query:"game_id"`    // Limit 100
-	Language     []string `query:"language"`   // Limit 100
-	Type         string   `query:"type,all"`   // "all" (default), "live" and "vodcast"
-	UserIDs      []string `query:"user_id"`    // limit 100
-	UserLogins   []string `query:"user_login"` // limit 100
+	After      string   `query:"after"`
+	Before     string   `query:"before"`
+	First      int      `query:"first,20"`   // Limit 100
+	GameIDs    []string `query:"game_id"`    // Limit 100
+	Language   []string `query:"language"`   // Limit 100
+	Type       string   `query:"type,all"`   // "all" (default), "live" and "vodcast"
+	UserIDs    []string `query:"user_id"`    // limit 100
+	UserLogins []string `query:"user_login"` // limit 100
 }
 
 // GetStreams ...

--- a/streams_test.go
+++ b/streams_test.go
@@ -19,7 +19,7 @@ func TestGetStreams(t *testing.T) {
 			http.StatusOK,
 			&Options{ClientID: "my-client-id"},
 			2,
-			`{"data":[{"id":"27833742640","user_id":"19571641","user_name":"Ninja","game_id":"33214","community_ids":[],"type":"live","title":"I have lost my voice D: | twitter.com/Ninja","viewer_count":72124,"started_at":"2018-03-06T15:07:45Z","language":"en","thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_ninja-{width}x{height}.jpg"},{"id":"27834185424","user_id":"17337557","user_name":"DrDisrespect","game_id":"33214","community_ids":[],"type":"live","title":"Turbo Treehouses || @DrDisRespect","viewer_count":29687,"started_at":"2018-03-06T16:05:00Z","language":"en","thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_drdisrespectlive-{width}x{height}.jpg"}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6Mn19"}}`,
+			`{"data":[{"id":"27833742640","user_id":"19571641","user_name":"Ninja","game_id":"33214","tag_ids":[],"type":"live","title":"I have lost my voice D: | twitter.com/Ninja","viewer_count":72124,"started_at":"2018-03-06T15:07:45Z","language":"en","thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_ninja-{width}x{height}.jpg"},{"id":"27834185424","user_id":"17337557","user_name":"DrDisrespect","game_id":"33214","tag_ids":[],"type":"live","title":"Turbo Treehouses || @DrDisRespect","viewer_count":29687,"started_at":"2018-03-06T16:05:00Z","language":"en","thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_drdisrespectlive-{width}x{height}.jpg"}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6Mn19"}}`,
 		},
 		{
 			http.StatusBadRequest,


### PR DESCRIPTION
Replace the deprecated CommunityIDs slice with a new TagIDs slice since the Twitch API is no longer returning Community IDs in the GetStreams response or using it for requests.  This closes #29

ref: https://dev.twitch.tv/docs/api/reference/#get-streams

TESTED=
![image](https://user-images.githubusercontent.com/81324/67149887-e13a3480-f27e-11e9-8d2e-9ab3f9adf324.png)
