### PR TITLE
Validate user access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All documentation and usage examples for this package can be found in the [docs 
 - [x] Get User Access Tokens (OAuth Authorization Code Flow)
 - [x] Refresh User Access Tokens
 - [x] Revoke User Access Tokens
+- [x] Validate Access Token
 
 **API Endpoint:**
 

--- a/docs/authentication_docs.md
+++ b/docs/authentication_docs.md
@@ -108,3 +108,29 @@ if err != nil {
 
 fmt.Printf("%+v\n", resp)
 ```
+
+## Validate User Access Token
+
+You can validate an access token and get token details in the following manner:
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+userAccessToken := "your-user-access-token-to-validate"
+
+isValid, resp, err := client.ValidateToken(userAccessToken)
+if err != nil {
+    // handle error
+}
+
+if isValid {
+    fmt.Println("%s access token is valid!", userAccessToken)
+}
+
+fmt.Println("%+v", resp)
+```

--- a/helix.go
+++ b/helix.go
@@ -388,8 +388,14 @@ func (c *Client) setRequestHeaders(req *http.Request) {
 		bearerToken = opts.UserAccessToken
 	}
 
+	authType := "Bearer"
+	// Token validation requires different type of Auth
+	if req.URL.String() == AuthBaseURL+authPaths["validate"] {
+		authType = "OAuth"
+	}
+
 	if bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", authType, bearerToken))
 	}
 }
 


### PR DESCRIPTION
This PR allows us to validate a user token and bring back some token details.

Since there is no way to easily avoid modifying the auth type (Bearer vs OAuth), a conditional check against the validation URL was put into setRequestHeaders. It's not the cleanest, but it's the only path that doesn't require a significant refactor.

This PR is related to an issue comment: https://github.com/nicklaw5/helix/issues/8#issuecomment-623754693