### PR TITLE
Change GetAuthorizationURL to response_type=token, and add Scopes

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -15,7 +15,7 @@ var authPaths = map[string]string{
 func (c *Client) GetAuthorizationURL(state string, forceVerify bool) string {
 	opts := c.opts
 
-	url := AuthBaseURL + "/authorize?response_type=code"
+	url := AuthBaseURL + "/authorize?response_type=token"
 	url += "&client_id=" + opts.ClientID
 	url += "&redirect_uri=" + opts.RedirectURI
 
@@ -36,8 +36,9 @@ func (c *Client) GetAuthorizationURL(state string, forceVerify bool) string {
 
 // AppAccessCredentials ...
 type AppAccessCredentials struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken string   `json:"access_token"`
+	ExpiresIn   int      `json:"expires_in"`
+	Scopes      []string `json:"scope"`
 }
 
 // AppAccessTokenResponse ...
@@ -61,6 +62,7 @@ func (c *Client) GetAppAccessToken() (*AppAccessTokenResponse, error) {
 		ClientSecret: opts.ClientSecret,
 		RedirectURI:  opts.RedirectURI,
 		GrantType:    "client_credentials",
+		Scope:        strings.Join(opts.Scopes, " "),
 	}
 
 	resp, err := c.post(authPaths["token"], &AppAccessCredentials{}, data)
@@ -72,6 +74,7 @@ func (c *Client) GetAppAccessToken() (*AppAccessTokenResponse, error) {
 	resp.HydrateResponseCommon(&token.ResponseCommon)
 	token.Data.AccessToken = resp.Data.(*AppAccessCredentials).AccessToken
 	token.Data.ExpiresIn = resp.Data.(*AppAccessCredentials).ExpiresIn
+	token.Data.Scopes = resp.Data.(*AppAccessCredentials).Scopes
 
 	return token, nil
 }
@@ -96,6 +99,7 @@ type accessTokenRequestData struct {
 	ClientSecret string `query:"client_secret"`
 	RedirectURI  string `query:"redirect_uri"`
 	GrantType    string `query:"grant_type"`
+	Scope        string `query:"scope"`
 }
 
 // GetUserAccessToken ...

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -21,7 +21,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 				ClientID:    "my-client-id",
 				RedirectURI: "https://example.com/auth/callback",
 			},
-			"https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=my-client-id&redirect_uri=https://example.com/auth/callback",
+			"https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=my-client-id&redirect_uri=https://example.com/auth/callback",
 		},
 		{
 			"some-state",
@@ -31,7 +31,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 				RedirectURI: "https://example.com/auth/callback",
 				Scopes:      []string{"analytics:read:games", "bits:read", "clips:edit", "user:edit", "user:read:email"},
 			},
-			"https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=my-client-id&redirect_uri=https://example.com/auth/callback&state=some-state&force_verify=true&scope=analytics:read:games%20bits:read%20clips:edit%20user:edit%20user:read:email",
+			"https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=my-client-id&redirect_uri=https://example.com/auth/callback&state=some-state&force_verify=true&scope=analytics:read:games%20bits:read%20clips:edit%20user:edit%20user:read:email",
 		},
 	}
 


### PR DESCRIPTION
Change GetAuthorizationURL to response_type=token, and add Scopes to AppAccessCredentials.

The old one only retrieved an app access token, but still required user intervention. This was unnecessary, as the app access tokens don't need user auth. Now this returns a user token, with proper scopes, and can be used with the Twitch pubsub server (wss://pubsub-edge.twitch.tv)