### PR TITLE
Add SearchChannels to search for offline channels

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -1,0 +1,56 @@
+package helix
+
+/*
+This file makes up for a missing API in Helix. This appears to be a recent
+change (as of around 2020-08-03) to the Twitch API, where GetStreams no longer
+returns information about offline channels.
+*/
+
+// SearchChannelsParams is parameters for SearchChannels
+type SearchChannelsParams struct {
+	Channel  string `query:"query"`
+	After    string `query:"after"`
+	First    int    `query:"first,20"` // Limit 100
+	LiveOnly bool   `query:"live_only"`
+}
+
+// ManySearchChannels is the response data from SearchChannels
+type ManySearchChannels struct {
+	Channels   []Channel  `json:"data"`
+	Pagination Pagination `json:"pagination"`
+}
+
+// Channel describes a channel from SearchChannel
+type Channel struct {
+	ID           string `json:"id"`
+	GameID       string `json:"game_id"`
+	DisplayName  string `json:"display_name"`
+	Language     string `json:"broadcaster_language"`
+	Title        string `json:"title"`
+	ThumbnailURL string `json:"thumbnail_url"`
+	IsLive       bool   `json:"is_live"`
+	// StartedAt    time.Time `json:"started_at"` // This can be invalid if the channel is not live; omitting it. Prefer GetStreams for live channels.
+	TagIDs []string `json:"tag_ids"`
+}
+
+// SearchChannelsResponse is the response from SearchChannels
+type SearchChannelsResponse struct {
+	ResponseCommon
+	Data ManySearchChannels
+}
+
+// SearchChannels searches for Twitch channels based on the given search
+// parameters. Unlike GetStreams, this can also return offline channels.
+func (c *Client) SearchChannels(params *SearchChannelsParams) (*SearchChannelsResponse, error) {
+	resp, err := c.get("/search/channels", &ManySearchChannels{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	channels := &SearchChannelsResponse{}
+	resp.HydrateResponseCommon(&channels.ResponseCommon)
+	channels.Data.Channels = resp.Data.(*ManySearchChannels).Channels
+	channels.Data.Pagination = resp.Data.(*ManySearchChannels).Pagination
+
+	return channels, nil
+}

--- a/channels.go
+++ b/channels.go
@@ -1,11 +1,5 @@
 package helix
 
-/*
-This file makes up for a missing API in Helix. This appears to be a recent
-change (as of around 2020-08-03) to the Twitch API, where GetStreams no longer
-returns information about offline channels.
-*/
-
 // SearchChannelsParams is parameters for SearchChannels
 type SearchChannelsParams struct {
 	Channel  string `query:"query"`
@@ -22,15 +16,15 @@ type ManySearchChannels struct {
 
 // Channel describes a channel from SearchChannel
 type Channel struct {
-	ID           string `json:"id"`
-	GameID       string `json:"game_id"`
-	DisplayName  string `json:"display_name"`
-	Language     string `json:"broadcaster_language"`
-	Title        string `json:"title"`
-	ThumbnailURL string `json:"thumbnail_url"`
-	IsLive       bool   `json:"is_live"`
-	// StartedAt    time.Time `json:"started_at"` // This can be invalid if the channel is not live; omitting it. Prefer GetStreams for live channels.
-	TagIDs []string `json:"tag_ids"`
+	ID           string   `json:"id"`
+	GameID       string   `json:"game_id"`
+	DisplayName  string   `json:"display_name"`
+	Language     string   `json:"broadcaster_language"`
+	Title        string   `json:"title"`
+	ThumbnailURL string   `json:"thumbnail_url"`
+	IsLive       bool     `json:"is_live"`
+	StartedAt    Time     `json:"started_at"`
+	TagIDs       []string `json:"tag_ids"`
 }
 
 // SearchChannelsResponse is the response from SearchChannels

--- a/channels_test.go
+++ b/channels_test.go
@@ -1,0 +1,109 @@
+package helix
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSearchChannels(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode int
+		options    *Options
+		First      int
+		respBody   string
+		parsed     []Channel
+	}{
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			2,
+			`{"data":[{"broadcaster_language":"en","display_name":"Ninja","game_id":"33214","id":"27833742640","is_live":false,"tag_ids":[],"thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_ninja-{width}x{height}.jpg","title":"I have lost my voice D: | twitter.com/Ninja","started_at":"2018-03-06T15:07:45Z"},{"broadcaster_language":"en","display_name":"DrDisrespect","game_id":"33214","id":"27834185424","is_live":false,"tag_ids":[],"thumbnail_url":"https://static-cdn.jtvnw.net/previews-ttv/live_user_drdisrespectlive-{width}x{height}.jpg","title":"Turbo Treehouses || @DrDisRespect","started_at":"2018-03-06T16:05:00Z"}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6Mn19"}}`,
+			[]Channel{
+				Channel{
+					ID:           "27833742640",
+					GameID:       "33214",
+					DisplayName:  "Ninja",
+					Language:     "en",
+					Title:        "I have lost my voice D: | twitter.com/Ninja",
+					ThumbnailURL: "https://static-cdn.jtvnw.net/previews-ttv/live_user_ninja-{width}x{height}.jpg",
+					IsLive:       false,
+					TagIDs:       []string{},
+				},
+				Channel{
+					ID:           "27834185424",
+					GameID:       "33214",
+					DisplayName:  "DrDisrespect",
+					Language:     "en",
+					Title:        "Turbo Treehouses || @DrDisRespect",
+					ThumbnailURL: "https://static-cdn.jtvnw.net/previews-ttv/live_user_drdisrespectlive-{width}x{height}.jpg",
+					IsLive:       false,
+					TagIDs:       []string{},
+				},
+			},
+		},
+		{
+			http.StatusBadRequest,
+			&Options{ClientID: "my-client-id"},
+			101,
+			`{"error":"Bad Request","status":400,"message":"The parameter \"first\" was malformed: the value must be less than or equal to 100"}`,
+			[]Channel{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.SearchChannels(&SearchChannelsParams{
+			First: testCase.First,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Test Bad Request Responses
+		if resp.StatusCode == http.StatusBadRequest {
+			firstErrStr := "The parameter \"first\" was malformed: the value must be less than or equal to 100"
+			if resp.ErrorMessage != firstErrStr {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", firstErrStr, resp.ErrorMessage)
+			}
+			continue
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		if len(resp.Data.Channels) != testCase.First {
+			t.Errorf("expected \"%d\" streams, got \"%d\"", testCase.First, len(resp.Data.Channels))
+		}
+
+		for i, channel := range resp.Data.Channels {
+			if channel.ID != testCase.parsed[i].ID {
+				t.Errorf("Expected struct field ID = %s, was %s", testCase.parsed[i].ID, channel.ID)
+			}
+			if channel.GameID != testCase.parsed[i].GameID {
+				t.Errorf("Expected struct field GameID = %s, was %s", testCase.parsed[i].GameID, channel.GameID)
+			}
+			if channel.DisplayName != testCase.parsed[i].DisplayName {
+				t.Errorf("Expected struct field DisplayName = %s, was %s", testCase.parsed[i].DisplayName, channel.DisplayName)
+			}
+			if channel.Language != testCase.parsed[i].Language {
+				t.Errorf("Expected struct field Language = %s, was %s", testCase.parsed[i].Language, channel.Language)
+			}
+			if channel.Title != testCase.parsed[i].Title {
+				t.Errorf("Expected struct field Title = %s, was %s", testCase.parsed[i].Title, channel.Title)
+			}
+			if channel.ThumbnailURL != testCase.parsed[i].ThumbnailURL {
+				t.Errorf("Expected struct field ThumbnailURL = %s, was %s", testCase.parsed[i].ThumbnailURL, channel.ThumbnailURL)
+			}
+			if channel.IsLive != testCase.parsed[i].IsLive {
+				t.Errorf("Expected struct field IsLive = %t, was %t", testCase.parsed[i].IsLive, channel.IsLive)
+			}
+			if len(channel.TagIDs) != len(testCase.parsed[i].TagIDs) {
+				t.Errorf("Expected struct field TagIDs length = %d, was %d", len(testCase.parsed[i].TagIDs), len(channel.TagIDs))
+			}
+		}
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Follow the links below to their respective API usage examples:
 - [Analytics](analytics_docs.md)
 - [Authentication](authentication_docs.md)
 - [Bits](bits_docs.md)
+- [Channels](channels_docs.md)
 - [Clips](clips_docs.md)
 - [Entitlement Grants](entitlement_grants_docs.md)
 - [Games](games_docs.md)

--- a/docs/channels_docs.md
+++ b/docs/channels_docs.md
@@ -2,7 +2,7 @@
 
 ## Search Channels
 
-This is an example of how to search channels. Here we are requesting the first two streams from the English language. SearchChannels returns live as well as offline channelsl.
+This is an example of how to search channels. Here we are requesting the first two streams from the English language. SearchChannels returns live as well as offline channels.
 
 ```go
 client, err := helix.NewClient(&helix.Options{

--- a/docs/channels_docs.md
+++ b/docs/channels_docs.md
@@ -1,0 +1,24 @@
+# Channels Documentation
+
+## Search Channels
+
+This is an example of how to search channels. Here we are requesting the first two streams from the English language. SearchChannels returns live as well as offline channelsl.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.SearchChannels(&helix.SearchChannelsParams{
+    First: 2,
+    Language: []string{"en"},
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```

--- a/streams.go
+++ b/streams.go
@@ -41,7 +41,8 @@ type StreamsParams struct {
 	UserLogins []string `query:"user_login"` // limit 100
 }
 
-// GetStreams ...
+// GetStreams returns a list of live channels based on the search parameters.
+// To query offline channels, use SearchChannels.
 func (c *Client) GetStreams(params *StreamsParams) (*StreamsResponse, error) {
 	resp, err := c.get("/streams", &ManyStreams{}, params)
 	if err != nil {


### PR DESCRIPTION
Twitch change the GetStreams API to only return live channels. This supplements by allowing to search for offline as well as live channels.