### PR TITLE
Refactor access token methods

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -55,8 +55,8 @@ type AppAccessTokenResponse struct {
 	Data AccessCredentials
 }
 
-// GetAppAccessToken ...
-func (c *Client) GetAppAccessToken(scopes []string) (*AppAccessTokenResponse, error) {
+// RequestAppAccessToken ...
+func (c *Client) RequestAppAccessToken(scopes []string) (*AppAccessTokenResponse, error) {
 	opts := c.opts
 	data := &accessTokenRequestData{
 		ClientID:     opts.ClientID,
@@ -96,8 +96,8 @@ type accessTokenRequestData struct {
 	Scopes       []string `query:"scope"`
 }
 
-// GetUserAccessToken ...
-func (c *Client) GetUserAccessToken(code string) (*UserAccessTokenResponse, error) {
+// RequestUserAccessToken ...
+func (c *Client) RequestUserAccessToken(code string) (*UserAccessTokenResponse, error) {
 	opts := c.opts
 	data := &accessTokenRequestData{
 		Code:         code,

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -56,7 +56,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 	}
 }
 
-func TestGetAppAccessToken(t *testing.T) {
+func TestRequestAppAccessToken(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -97,7 +97,7 @@ func TestGetAppAccessToken(t *testing.T) {
 	for _, testCase := range testCases {
 		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
 
-		resp, err := c.GetAppAccessToken([]string{"some-scope"})
+		resp, err := c.RequestAppAccessToken([]string{"some-scope"})
 		if err != nil {
 			t.Error(err)
 		}
@@ -130,7 +130,7 @@ func TestGetAppAccessToken(t *testing.T) {
 	}
 }
 
-func TestGetUserAccessToken(t *testing.T) {
+func TestRequestUserAccessToken(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -218,7 +218,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	for _, testCase := range testCases {
 		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
 
-		resp, err := c.GetUserAccessToken(testCase.code)
+		resp, err := c.RequestUserAccessToken(testCase.code)
 		if err != nil {
 			t.Error(err)
 		}

--- a/docs/authentication_docs.md
+++ b/docs/authentication_docs.md
@@ -45,7 +45,7 @@ if err != nil {
 
 code := "your-authentication-code"
 
-resp, err := client.GetUserAccessToken(code)
+resp, err := client.RequestUserAccessToken(code)
 if err != nil {
     // handle error
 }
@@ -91,7 +91,7 @@ if err != nil {
     // handle error
 }
 
-userAccessToken := "your-user-access-token-to-revoke"
+userAccessToken := client.GetUserAccessToken()
 
 resp, err := client.RevokeUserAccessToken(userAccessToken)
 if err != nil {
@@ -113,7 +113,7 @@ if err != nil {
     // handle error
 }
 
-userAccessToken := "your-user-access-token-to-validate"
+userAccessToken := client.GetUserAccessToken()
 
 isValid, resp, err := client.ValidateToken(userAccessToken)
 if err != nil {
@@ -140,7 +140,7 @@ if err != nil {
     // handle error
 }
 
-resp, err := client.GetAppAccessToken([]string{"user:read:email"})
+resp, err := client.RequestAppAccessToken([]string{"user:read:email"})
 if err != nil {
     // handle error
 }

--- a/helix.go
+++ b/helix.go
@@ -404,11 +404,21 @@ func setResponseStatusCode(v interface{}, fieldName string, code int) {
 	field.SetInt(int64(code))
 }
 
+// GetAppAccessToken returns the current app access token.
+func (c *Client) GetAppAccessToken() string {
+	return c.opts.AppAccessToken
+}
+
 // SetAppAccessToken ...
 func (c *Client) SetAppAccessToken(accessToken string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.opts.AppAccessToken = accessToken
+}
+
+// GetUserAccessToken returns the current user access token.
+func (c *Client) GetUserAccessToken() string {
+	return c.opts.UserAccessToken
 }
 
 // SetUserAccessToken ...

--- a/helix_test.go
+++ b/helix_test.go
@@ -387,6 +387,25 @@ func TestDecodingBadJSON(t *testing.T) {
 	}
 }
 
+func TestGetAppAccessToken(t *testing.T) {
+	t.Parallel()
+
+	accessToken := "my-app-access-token"
+
+	client, err := NewClient(&Options{
+		ClientID: "cid",
+	})
+	if err != nil {
+		t.Errorf("Did not expect an error, got \"%s\"", err.Error())
+	}
+
+	client.SetAppAccessToken(accessToken)
+
+	if client.GetAppAccessToken() != accessToken {
+		t.Errorf("expected GetAppAccessToken to return \"%s\", got \"%s\"", accessToken, client.GetAppAccessToken())
+	}
+}
+
 func TestSetAppAccessToken(t *testing.T) {
 	t.Parallel()
 
@@ -403,6 +422,25 @@ func TestSetAppAccessToken(t *testing.T) {
 
 	if client.opts.AppAccessToken != accessToken {
 		t.Errorf("expected accessToken to be \"%s\", got \"%s\"", accessToken, client.opts.AppAccessToken)
+	}
+}
+
+func TestGetUserAccessToken(t *testing.T) {
+	t.Parallel()
+
+	accessToken := "my-user-access-token"
+
+	client, err := NewClient(&Options{
+		ClientID: "cid",
+	})
+	if err != nil {
+		t.Errorf("Did not expect an error, got \"%s\"", err.Error())
+	}
+
+	client.SetUserAccessToken(accessToken)
+
+	if client.GetUserAccessToken() != accessToken {
+		t.Errorf("expected GetUserAccessToken to return \"%s\", got \"%s\"", accessToken, client.GetUserAccessToken())
 	}
 }
 


### PR DESCRIPTION
\*\*\****Breaking Change***\*\*\*

Changes:
- Renamed `GetUserAccessToken` method to `RequestUserAccessToken`
- Renamed `GetAppAccessToken` method to `RequestAppAccessToken`
- Add two new methods `GetUserAccessToken` and `GetAppAccessToken` for returning the currently set access tokens

Closes #56 