### PR TITLE
Update streams_docs.md

### DIFF
--- a/docs/streams_docs.md
+++ b/docs/streams_docs.md
@@ -22,22 +22,3 @@ if err != nil {
 
 fmt.Printf("%+v\n", resp)
 ```
-
-## Get Streams Metadata
-
-This is an example of how to get streams metadata. Here we are requesting the first two streams from Hearthstone.
-
-```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
-if err != nil {
-    // handle error
-}
-
-resp, _ := client.GetStreamsMetadata(&helix.StreamsMetadataParams{
-    First:   2,
-    GameIDs: []string{"138585"}, // Hearthstone
-})
-fmt.Printf("%+v\n", resp)
-```


### PR DESCRIPTION
Streams metadata deprecated on July 20, 2020 https://discuss.dev.twitch.tv/t/deprecation-of-the-helix-get-streams-metadata-endpoint/26407