### PR TITLE
Correcting scopes to pass as space-separated list

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -63,7 +63,7 @@ func (c *Client) RequestAppAccessToken(scopes []string) (*AppAccessTokenResponse
 		ClientSecret: opts.ClientSecret,
 		RedirectURI:  opts.RedirectURI,
 		GrantType:    "client_credentials",
-		Scopes:       scopes,
+		Scopes:       strings.Join(scopes, " "),
 	}
 
 	resp, err := c.post(authPaths["token"], &AccessCredentials{}, data)
@@ -88,12 +88,12 @@ type UserAccessTokenResponse struct {
 }
 
 type accessTokenRequestData struct {
-	Code         string   `query:"code"`
-	ClientID     string   `query:"client_id"`
-	ClientSecret string   `query:"client_secret"`
-	RedirectURI  string   `query:"redirect_uri"`
-	GrantType    string   `query:"grant_type"`
-	Scopes       []string `query:"scope"`
+	Code         string `query:"code"`
+	ClientID     string `query:"client_id"`
+	ClientSecret string `query:"client_secret"`
+	RedirectURI  string `query:"redirect_uri"`
+	GrantType    string `query:"grant_type"`
+	Scopes       string `query:"scope"`
 }
 
 // RequestUserAccessToken ...


### PR DESCRIPTION
Correcting scopes to pass as space-separated list, rather than &scope…=...&scope=..., per the [documentation](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/). 

Without this change, the API only recognizes the first scope that is passed.

Existing tests are unaffected either way. The difference is that when scopes are actually being requested against a live twitch service, the scopes that are returned always only reflects the first one in the list.