### PR TITLE
Adding Redeem Code endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ looking for the Twitch API docs, see the [Twitch Developer website](https://dev.
 - [x] Create Entitlement Grants Upload URL
 - [x] Get Code Status
 - [x] Get Drops Entitlements
-- [ ] Redeem Code
+- [x] Redeem Code
 - [x] Get Top Games
 - [x] Get Games
 - [ ] Get Hype Train Events

--- a/entitlement_codes.go
+++ b/entitlement_codes.go
@@ -55,3 +55,21 @@ func (c *Client) GetEntitlementCodeStatus(params *CodesParams) (*CodeResponse, e
 
 	return codes, nil
 }
+
+/**
+Per https://dev.twitch.tv/docs/api/reference/#redeem-code
+Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch.
+Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
+*/
+func (c *Client) RedeemEntitlementCode(params *CodesParams) (*CodeResponse, error) {
+	resp, err := c.post("/entitlements/code", &ManyCodes{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	codes := &CodeResponse{}
+	resp.HydrateResponseCommon(&codes.ResponseCommon)
+	codes.Data.Codes = resp.Data.(*ManyCodes).Codes
+
+	return codes, nil
+}

--- a/entitlement_codes_test.go
+++ b/entitlement_codes_test.go
@@ -60,3 +60,59 @@ func TestClient_GetEntitlementCodeStatus(t *testing.T) {
 
 	}
 }
+
+func TestClient_RedeemEntitlementCode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode int
+		options    *Options
+		count      int
+		userId     string
+		codes      []string
+		respBody   string
+	}{
+		// TODO: expand with other test cases, including negative scenarios
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			2,
+			"156900877",
+			[]string{"KUHXV-4GXYP-AKAKK", "XZDDZ-5SIQR-RT5M3"},
+			`{"data":[{"code":"KUHXV-4GXYP-AKAKK","status":"SUCCESSFULLY_REDEEMED"},{"code":"XZDDZ-5SIQR-RT5M3","status":"ALREADY_CLAIMED"}]}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		params := &CodesParams{
+			UserID: testCase.userId,
+			Codes:  testCase.codes,
+		}
+
+		resp, err := c.GetEntitlementCodeStatus(params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		// TODO: Test error cases
+
+		// Test success cases
+		if len(resp.Data.Codes) != testCase.count {
+			t.Errorf("expected number of results to be \"%d\", got \"%d\"", testCase.count, len(resp.Data.Codes))
+		}
+
+		for index, code := range testCase.codes {
+			codes := resp.Data.Codes[index]
+			if codes.Code != code {
+				t.Error("expected entitlement code \"#{code}\", got \"#{codes.Code}\"")
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
per #8 
Turned out the redemption is almost identical with the status endpoint, was a bit of copy/paste with slight edits to get this in place.