### PR TITLE
Add channel points custom rewards creation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ looking for the Twitch API docs, see the [Twitch Developer website](https://dev.
 - [x] Get Channel Information
 - [x] Modify Channel Information
 - [x] Get Channel Editors
-- [ ] Create Custom Rewards
+- [x] Create Custom Rewards
 - [ ] Delete Custom Reward
 - [ ] Get Custom Reward
 - [ ] Get Custom Reward Redemption
@@ -60,12 +60,12 @@ looking for the Twitch API docs, see the [Twitch Developer website](https://dev.
 - [x] Get Banned Users
 - [ ] Get Moderators
 - [ ] Get Moderator Events
-- [x] Get Polls         {beta}
-- [x] Create Poll       {beta}
-- [x] End Poll          {beta}
-- [x] Get Predictions   {beta}
-- [x] Create Prediction {beta}
-- [x] End Prediction    {beta}
+- [x] Get Polls
+- [x] Create Poll
+- [x] End Poll
+- [x] Get Predictions
+- [x] Create Prediction
+- [x] End Prediction
 - [ ] Search Categories
 - [ ] Search Channels
 - [ ] Get Stream Key

--- a/channels.go
+++ b/channels.go
@@ -83,12 +83,13 @@ type ManyChannelInformation struct {
 
 // ChannelInformation ...
 type ChannelInformation struct {
-	BroadcasterID         string `json:"broadcaster_id"`
-	BroadcasterName    string `json:"broadcaster_name"`
-	BroadcasterLanguage   string `json:"broadcaster_language"`
-	GameID string `json:"game_id"`
-	GameName   string `json:"game_name"`
-	Title      string `json:"title"`
+	BroadcasterID       string `json:"broadcaster_id"`
+	BroadcasterName     string `json:"broadcaster_name"`
+	BroadcasterLanguage string `json:"broadcaster_language"`
+	Delay               string `json:"delay"`
+	GameID              string `json:"game_id"`
+	GameName            string `json:"game_name"`
+	Title               string `json:"title"`
 }
 
 // GetChannelInformation ...

--- a/channels_points.go
+++ b/channels_points.go
@@ -1,0 +1,93 @@
+package helix
+
+// ChannelCustomRewardsParams ...
+type ChannelCustomRewardsParams struct {
+	BroadcasterID                     string `query:"broadcaster_id"`
+	Title                             string `json:"title"`
+	Cost                              int    `json:"cost"`
+	Prompt                            string `json:"prompt"`
+	IsEnabled                         bool   `json:"is_enabled"`
+	BackgroundColor                   string `json:"background_color"`
+	IsUserInputRequired               bool   `json:"is_user_input_required"`
+	IsMaxPerStreamEnabled             bool   `json:"is_max_per_stream_enabled"`
+	MaxPerStream                      int    `json:"max_per_stream"`
+	IsMaxPerUserPerStreamEnabled      bool   `json:"is_max_per_user_per_stream_enabled"`
+	MaxPerUserPerStream               int    `json:"max_per_user_per_stream"`
+	IsGlobalCooldownEnabled           bool   `json:"is_global_cooldown_enabled"`
+	GlobalCooldownSeconds             int    `json:"global_cooldown_seconds"`
+	ShouldRedemptionsSkipRequestQueue bool   `json:"should_redemptions_skip_request_queue"`
+}
+
+// ChannelCustomRewards ...
+type ManyChannelCustomRewards struct {
+	ChannelCustomRewards []ChannelCustomReward `json:"data"`
+}
+
+// ChannelCustomReward ...
+type ChannelCustomReward struct {
+	BroadcasterID                     string                      `json:"broadcaster_id"`
+	BroadcasterLogin                  string                      `json:"broadcaster_login"`
+	BroadcasterName                   string                      `json:"broadcaster_name"`
+	ID                                string                      `json:"id"`
+	Title                             string                      `json:"title"`
+	Prompt                            string                      `json:"prompt"`
+	Cost                              int                         `json:"cost"`
+	Image                             RewardImage                 `json:"image"`
+	DefaultImage                      RewardImage                 `json:"default_image"`
+	IsEnabled                         bool                        `json:"is_enabled"`
+	IsUserInputRequired               bool                        `json:"is_user_input_required"`
+	MaxPerStreamSetting               MaxPerStreamSettings        `json:"max_per_stream_setting"`
+	MaxPerUserPerStreamSetting        MaxPerUserPerStreamSettings `json:"max_per_user_per_stream_setting"`
+	GlobalCooldownSetting             GlobalCooldownSettings      `json:"global_cooldown_setting"`
+	IsPaused                          bool                        `json:"is_paused"`
+	IsInStock                         bool                        `json:"is_in_stock"`
+	ShouldRedemptionsSkipRequestQueue bool                        `json:"should_redemptions_skip_request_queue"`
+	RedemptionsRedeemedCurrentStream  int                         `json:"redemptions_redeemed_current_stream"`
+	CooldownExpiresAt                 string                      `json:"cooldown_expires_at"`
+}
+
+// RewardImage ...
+type RewardImage struct {
+	Url1 string `json:"url_1x"`
+	Url2 string `json:"url_2x"`
+	Url4 string `json:"url_4x"`
+}
+
+// MaxPerUserPerStreamSettings ...
+type MaxPerUserPerStreamSettings struct {
+	IsEnabled           bool `json:"is_enabled"`
+	MaxPerUserPerStream int  `json:"max_per_user_per_stream"`
+}
+
+// MaxPerStreamSettings ...
+type MaxPerStreamSettings struct {
+	IsEnabled    bool `json:"is_enabled"`
+	MaxPerStream int  `json:"max_per_stream"`
+}
+
+// GlobalCooldownSettings ...
+type GlobalCooldownSettings struct {
+	IsEnabled             bool `json:"is_enabled"`
+	GlobalCooldownSeconds int  `json:"global_cooldown_seconds"`
+}
+
+// ChannelCustomRewardResponse ...
+type ChannelCustomRewardResponse struct {
+	ResponseCommon
+	Data ManyChannelCustomRewards
+}
+
+// CreateCustomReward : Creates a Custom Reward on a channel.
+// Required scope: channel:manage:redemptions
+func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	reward := &ChannelCustomRewardResponse{}
+	resp.HydrateResponseCommon(&reward.ResponseCommon)
+	reward.Data.ChannelCustomRewards = resp.Data.(*ManyChannelCustomRewards).ChannelCustomRewards
+
+	return reward, nil
+}

--- a/channels_points_test.go
+++ b/channels_points_test.go
@@ -1,0 +1,76 @@
+package helix
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCreateCustomReward(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode  int
+		options     *Options
+		params      *ChannelCustomRewardsParams
+		respBody    string
+	}{
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&ChannelCustomRewardsParams{
+				BroadcasterID : "145328278",
+				Title         : "game analysis 1v1",
+				Cost          : 50000,
+			},
+			`{"data": [{"broadcaster_name": "torpedo09","broadcaster_login": "torpedo09","broadcaster_id": "145328278","id": "afaa7e34-6b17-49f0-a19a-d1e76eaaf673","image": null,"background_color": "#00E5CB","is_enabled": true,"cost": 50000,"title": "game analysis 1v1","prompt": "","is_user_input_required": false,"max_per_stream_setting": {"is_enabled": false,"max_per_stream": 0},"max_per_user_per_stream_setting": {"is_enabled": false,"max_per_user_per_stream": 0},"global_cooldown_setting": {"is_enabled": false,"global_cooldown_seconds": 0},"is_paused": false,"is_in_stock": true,"default_image": {"url_1x": "https://static-cdn.jtvnw.net/custom-reward-images/default-1.png","url_2x": "https://static-cdn.jtvnw.net/custom-reward-images/default-2.png","url_4x": "https://static-cdn.jtvnw.net/custom-reward-images/default-4.png"},"should_redemptions_skip_request_queue": false,"redemptions_redeemed_current_stream": null,"cooldown_expires_at": null}]}`,
+		},
+		{
+			http.StatusBadRequest,
+			&Options{ClientID: "my-client-id"},
+			&ChannelCustomRewardsParams{},
+			`{"error":"Bad Request","status":400,"message":"Missing required parameter \"broadcaster_id\""}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.CreateCustomReward(testCase.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Test Bad Request Responses
+		if resp.StatusCode == http.StatusBadRequest {
+			firstErrStr := "Missing required parameter \"broadcaster_id\""
+			if resp.ErrorMessage != firstErrStr {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", firstErrStr, resp.ErrorMessage)
+			}
+			continue
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+	}
+
+    // Test with HTTP Failure
+	options := &Options{
+		ClientID: "my-client-id",
+		HTTPClient: &badMockHTTPClient{
+			newMockHandler(0, "", nil),
+		},
+	}
+	c := &Client{
+		opts: options,
+	}
+
+	_, err := c.CreateCustomReward(&ChannelCustomRewardsParams{})
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+
+	if err.Error() != "Failed to execute API request: Oops, that's bad :(" {
+		t.Error("expected error does match return error")
+	}
+}

--- a/docs/channels_points_docs.md
+++ b/docs/channels_points_docs.md
@@ -1,0 +1,25 @@
+# Channels Points Documentation
+
+## Create Custom Rewards
+
+This is an example of how to create a custom reward.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.CreateCustomReward(&helix.ChannelCustomRewardsParams{
+    BroadcasterID : "145328278",
+    Title         : "game analysis 1v1",
+    Cost          : 50000,
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```


### PR DESCRIPTION
Update from twitch changelog 2021‑05‑24
 - Polls and Channel Points Predictions Twitch API endpoints have moved from public beta to general availability.
 - Polls and Channel Points Predictions EventSub subscription types have moved from public beta to version 1.

Update from twitch changelog 2021‑05‑21
 - Extension Bits Transaction Create EventSub subscription type has been added as a public beta.
 - Channel Points Custom Rewards - The API reference for Custom Rewards endpoints has been updated for consistency and to clarify conditional requirements for body parameters. For example, max_per_stream is required if a value for is_max_per_stream_enabled is also provided.

Update from twitch changelog 2021‑05‑14
 - Channel Prediction Lock EventSub subscription type - corrected the name of the lock timestamp to locked_at.
 - Channel Prediction End EventSub subscription type - removed the locked_at field due to edge cases with Predictions that are cancelled or closed early.
 - Create EventSub Subscription and Get EventSub Subscriptions - limit removed following the new EventSub subscription limit cost-based system.
 - Get Channel Information - Added delay to return values table and example payload.