### PR TITLE
Add GetExtensionTransactions method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ A Twitch Helix API client written in Go (Golang).
 
 ## Package Status
 
-This project is a work in progress. Twitch has not finished all available endpoints/features for the Helix
-API, but as these get released they are likely to be implemented in this package.
+Twitch is always expanding and improving the available endpoints and features for the Helix API.
+The maintainers of this package will make a best effort approach to implementing new changes
+as they are released by the Twitch team.
 
 ## Documentation & Examples
 
-All documentation and usage examples for this package can be found in the [docs directory](docs). If you are
-looking for the Twitch API docs, see the [Twitch Developer website](https://dev.twitch.tv/docs/api).
+All documentation and usage examples for this package can be found in the [docs directory](docs).
+If you are looking for the Twitch API docs, see the [Twitch Developer website](https://dev.twitch.tv/docs/api).
 
 ## Supported Endpoints & Features
 
@@ -33,7 +34,7 @@ looking for the Twitch API docs, see the [Twitch Developer website](https://dev.
 - [x] Get Game Analytics
 - [x] Get Bits Leaderboard
 - [x] Get Cheermotes
-- [ ] Get Extension Transactions
+- [x] Get Extension Transactions
 - [x] Get Channel Information
 - [x] Modify Channel Information
 - [x] Get Channel Editors
@@ -109,8 +110,8 @@ looking for the Twitch API docs, see the [Twitch Developer website](https://dev.
 
 ## Quick Usage Example
 
-This is a quick example of how to get users. Note that you don't need to provide both a list of ids and logins,
-one or the other will suffice.
+This is a quick example of how to get users.
+Note that you don't need to provide both a list of ids and logins, one or the other will suffice.
 
 ```go
 client, err := helix.NewClient(&helix.Options{
@@ -154,7 +155,10 @@ ID: 23161357 Name: lirik
 
 ## Contributions
 
-PRs are very much welcome. Where possible, please write tests for any code that is introduced by your PRs.
+PRs are very much welcome.
+All new features should rely solely on the Go standard library.
+No external dependencies should be included in your solutions.
+Where possible, please include tests for any code that is introduced by your PRs.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Follow the links below to their respective API usage examples:
 - [Channels](channels_docs.md)
 - [Clips](clips_docs.md)
 - [Entitlement Grants](entitlement_grants_docs.md)
+- [Extensions](extensions_docs.md)
 - [Games](games_docs.md)
 - [Streams](streams_docs.md)
 - [Users](users_docs.md)

--- a/docs/extensions_docs.md
+++ b/docs/extensions_docs.md
@@ -1,0 +1,26 @@
+# Extensions Documentation
+
+## Get Extension Transactions
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID:        "your-client-id",
+    UserAccessToken: "your-user-access-token",
+})
+if err != nil {
+    // handle error
+}
+
+params := helix.ExtensionTransactionsParams{
+    ExtensionID: "some-extension-id",                              // Required
+    ID:          []string{"74c52265-e214-48a6-91b9-23b6014e8041"}, // Optional
+    First:       1,                                                // Optional
+}
+
+resp, err := client.GetExtensionTransactions(&params)
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```

--- a/extensions.go
+++ b/extensions.go
@@ -1,0 +1,60 @@
+package helix
+
+type ExtensionTransaction struct {
+	ID               string `json:"id"`
+	Timestamp        Time   `json:"timestamp"`
+	BroadcasterID    string `json:"broadcaster_id"`
+	BroadcasterLogin string `json:"broadcaster_login"`
+	BroadcasterName  string `json:"broadcaster_name"`
+	UserID           string `json:"user_id"`
+	UserLogin        string `json:"user_login"`
+	UserName         string `json:"user_name"`
+	ProductType      string `json:"product_type"`
+	ProductData      struct {
+		Domain     string `json:"domain"`
+		Broadcast  bool   `json:"broadcast"`
+		Expiration string `json:"expiration"`
+		SKU        string `json:"sku"`
+		Cost       struct {
+			Amount int    `json:"amount"`
+			Type   string `json:"type"`
+		} `json:"cost"`
+		DisplayName   string `json:"displayName"`
+		InDevelopment bool   `json:"inDevelopment"`
+	} `json:"product_data"`
+}
+
+type ManyExtensionTransactions struct {
+	ExtensionTransactions []ExtensionTransaction `json:"data"`
+	Pagination            Pagination             `json:"pagination"`
+}
+
+type ExtensionTransactionsResponse struct {
+	ResponseCommon
+	Data ManyExtensionTransactions
+}
+
+type ExtensionTransactionsParams struct {
+	ExtensionID string   `query:"extension_id"` // Required
+	ID          []string `query:"id"`           // Optional, Limit 100
+	After       string   `query:"after"`        // Optional
+	First       int      `query:"first,20"`     // Optional, Limit 100
+}
+
+// GetExtensionTransactions allows extension back end servers to fetch a list of transactions that
+// have occurred for their extension across all of Twitch. A transaction is a record of a user
+// exchanging Bits for an in-Extension digital good.
+//
+// See https://dev.twitch.tv/docs/api/reference/#get-extension-transactions
+func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams) (*ExtensionTransactionsResponse, error) {
+	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	extTxnResp := &ExtensionTransactionsResponse{}
+	resp.HydrateResponseCommon(&extTxnResp.ResponseCommon)
+	extTxnResp.Data.ExtensionTransactions = resp.Data.(*ManyExtensionTransactions).ExtensionTransactions
+	extTxnResp.Data.Pagination = resp.Data.(*ManyExtensionTransactions).Pagination
+	return extTxnResp, nil
+}

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -1,0 +1,101 @@
+package helix
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetExtensionTransactions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode     int
+		options        *Options
+		params         *ExtensionTransactionsParams
+		respBody       string
+		expectedErrMsg string
+	}{
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&ExtensionTransactionsParams{ExtensionID: "some-extension-id"},
+			`{"data":[{"id":"74c52265-e214-48a6-91b9-23b6014e8041","timestamp":"2019-01-28T04:15:53.325Z","broadcaster_id":"439964613","broadcaster_login":"chikuseuma","broadcaster_name":"chikuseuma","user_id":"424596340","user_login":"quotrok","user_name":"quotrok","product_type":"BITS_IN_EXTENSION","product_data":{"sku":"testSku100","cost":{"amount":100,"type":"bits"},"displayName":"Test Sku","inDevelopment":false}}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6M319"}}`,
+			"",
+		},
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&ExtensionTransactionsParams{ExtensionID: "some-extension-id", ID: []string{"74c52265-e214-48a6-91b9-23b6014e8041", "8d303dc6-a460-4945-9f48-59c31d6735cb"}, First: 2},
+			`{"data":[{"id":"74c52265-e214-48a6-91b9-23b6014e8041","timestamp":"2019-01-28T04:15:53.325Z","broadcaster_id":"439964613","broadcaster_login":"chikuseuma","broadcaster_name":"chikuseuma","user_id":"424596340","user_login":"quotrok","user_name":"quotrok","product_type":"BITS_IN_EXTENSION","product_data":{"sku":"testSku100","cost":{"amount":100,"type":"bits"},"displayName":"Test Sku","inDevelopment":false}},{"id":"8d303dc6-a460-4945-9f48-59c31d6735cb","timestamp":"2019-01-18T09:10:13.397Z","broadcaster_id":"439964613","broadcaster_login":"chikuseuma","broadcaster_name":"chikuseuma","user_id":"439966926","user_login":"liscuit","user_name":"liscuit","product_type":"BITS_IN_EXTENSION","product_data":{"sku":"testSku100","cost":{"amount":100,"type":"bits"},"displayName":"Test Sku","inDevelopment":false}}],"pagination":{"cursor":"eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6M319"}}`,
+			"",
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.GetExtensionTransactions(testCase.params)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		if resp.StatusCode == http.StatusForbidden {
+			if resp.Error != "Forbidden" {
+				t.Errorf("expected error to be \"%s\", got \"%s\"", "Bad Request", resp.Error)
+			}
+
+			if resp.ErrorStatus != http.StatusForbidden {
+				t.Errorf("expected error status to be \"%d\", got \"%d\"", http.StatusForbidden, resp.ErrorStatus)
+			}
+
+			if resp.ErrorMessage != testCase.expectedErrMsg {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", testCase.expectedErrMsg, resp.ErrorMessage)
+			}
+
+			continue
+		}
+
+		if testCase.params.First != 0 && testCase.params.First != len(resp.Data.ExtensionTransactions) {
+			t.Errorf("expected %d transactions, got %d", testCase.params.First, len(resp.Data.ExtensionTransactions))
+		}
+
+		if testCase.params.ID != nil {
+			for _, ID := range testCase.params.ID {
+				found := false
+				for _, txn := range resp.Data.ExtensionTransactions {
+					if txn.ID == ID {
+						found = true
+					}
+				}
+
+				if !found {
+					t.Errorf("expected response to conatin transaction id %s, but didn't", ID)
+				}
+			}
+		}
+	}
+
+	// Test with HTTP Failure
+	c, err := NewClient(&Options{
+		ClientID: "my-client-id",
+		HTTPClient: &badMockHTTPClient{
+			newMockHandler(0, "", nil),
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = c.GetExtensionTransactions(&ExtensionTransactionsParams{})
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+
+	if err.Error() != "Failed to execute API request: Oops, that's bad :(" {
+		t.Error("expected error does match return error")
+	}
+}


### PR DESCRIPTION
Adds support for the `/extensions/transactions` endpoint.

See https://dev.twitch.tv/docs/api/reference/#get-extension-transactions