### PR TITLE
channelinfo: fix delay field type

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -86,10 +86,10 @@ type ChannelInformation struct {
 	BroadcasterID       string `json:"broadcaster_id"`
 	BroadcasterName     string `json:"broadcaster_name"`
 	BroadcasterLanguage string `json:"broadcaster_language"`
-	Delay               string `json:"delay"`
 	GameID              string `json:"game_id"`
 	GameName            string `json:"game_name"`
 	Title               string `json:"title"`
+	Delay               int    `json:"delay"`
 }
 
 // GetChannelInformation ...

--- a/channels_test.go
+++ b/channels_test.go
@@ -146,7 +146,7 @@ func TestGetChannelInformation(t *testing.T) {
 			http.StatusOK,
 			&Options{ClientID: "my-client-id"},
 			"44445592",
-			`{"data":[{"broadcaster_id":"44445592","broadcaster_login":"pokimane","broadcaster_name":"pokimane","broadcaster_language":"en","game_id":"509658","game_name":"Just Chatting","title":"See you Wednesday 8am for Among Us ^_^"}]}`,
+			`{"data":[{"broadcaster_id":"44445592","broadcaster_login":"pokimane","broadcaster_name":"pokimane","broadcaster_language":"en","game_id":"509658","game_name":"Just Chatting","title":"See you Wednesday 8am for Among Us ^_^", "delay": 2}]}`,
 			[]ChannelInformation{
 				{
 					BroadcasterID:       "44445592",
@@ -155,6 +155,7 @@ func TestGetChannelInformation(t *testing.T) {
 					GameID:              "509658",
 					GameName:            "Just Chatting",
 					Title:               "See you Wednesday 8am for Among Us ^_^",
+					Delay:               2,
 				},
 			},
 		},


### PR DESCRIPTION
first, thanks for making this project available! 

I was trying to use the Getchannelinfo and when made a request it failed
```
 Failed to decode API response: json: cannot unmarshal number into Go struct field ChannelInformation.data.delay of type string
 ```

checking the Twitch API https://dev.twitch.tv/docs/api/reference#get-channel-information the `delay` field is an Int and not string

this PR fixes that

