### PR TITLE
Fix GetEmoteSets method missing OwnerID in emote response

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -74,9 +74,20 @@ type GetChannelEmotesResponse struct {
 	Data ManyEmotes
 }
 
+// GetEmoteSetsResponse ...
+type GetEmoteSetsResponse struct {
+	ResponseCommon
+	Data ManyEmotesWithOwner
+}
+
 // ManyEmotes ...
 type ManyEmotes struct {
 	Emotes []Emote `json:"data"`
+}
+
+// EmoteSets ...
+type ManyEmotesWithOwner struct {
+	Emotes []EmoteWithOwner `json:"data"`
 }
 
 // Emote ...
@@ -87,6 +98,12 @@ type Emote struct {
 	Tier   string     `json:"tier"`
 	Type   string     `json:"emote_type"`
 	Set_ID string     `json:"emote_set_id"`
+}
+
+// EmoteWithOwner ...
+type EmoteWithOwner struct {
+	Emote
+	OwnerID string `json:"owner_id"`
 }
 
 // EmoteImage ...
@@ -125,15 +142,15 @@ func (c *Client) GetGlobalEmotes() (*GetChannelEmotesResponse, error) {
 }
 
 // GetEmoteSets
-func (c *Client) GetEmoteSets(params *GetEmoteSetsParams) (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes/set", &ManyEmotes{}, params)
+func (c *Client) GetEmoteSets(params *GetEmoteSetsParams) (*GetEmoteSetsResponse, error) {
+	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params)
 	if err != nil {
 		return nil, err
 	}
 
-	emotes := &GetChannelEmotesResponse{}
+	emotes := &GetEmoteSetsResponse{}
 	resp.HydrateResponseCommon(&emotes.ResponseCommon)
-	emotes.Data.Emotes = resp.Data.(*ManyEmotes).Emotes
+	emotes.Data.Emotes = resp.Data.(*ManyEmotesWithOwner).Emotes
 
 	return emotes, nil
 }

--- a/chat_test.go
+++ b/chat_test.go
@@ -324,7 +324,7 @@ func TestGetEmoteSets(t *testing.T) {
 						Images: EmoteImage{
 							Url1x: "https://static-cdn.jtvnw.net/emoticons/v1/301147694/1.0",
 							Url2x: "https://static-cdn.jtvnw.net/emoticons/v1/301147694/2.0",
-							Url4x: "https://static-cdn.jtvnw.net/emoticons/v1//3.0",
+							Url4x: "https://static-cdn.jtvnw.net/emoticons/v1/301147694/3.0",
 						},
 						Type:   "subscriptions",
 						Set_ID: "300678379",
@@ -332,7 +332,7 @@ func TestGetEmoteSets(t *testing.T) {
 					OwnerID: "44931651",
 				},
 			},
-			`{"data":[{"id":"301147694","name":"sixone3SixDab","images":{"url_1x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/1.0","url_2x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/2.0","url_4x":"https://static-cdn.jtvnw.net/emoticons/v1//3.0"},"emote_type":"subscriptions","emote_set_id":"300678379","owner_id":"44931651"}]}`,
+			`{"data":[{"id":"301147694","name":"sixone3SixDab","images":{"url_1x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/1.0","url_2x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/2.0","url_4x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/3.0"},"emote_type":"subscriptions","emote_set_id":"300678379","owner_id":"44931651"}]}`,
 		},
 	}
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -302,18 +302,36 @@ func TestGetEmoteSets(t *testing.T) {
 		statusCode         int
 		options            *Options
 		GetEmoteSetsParams *GetEmoteSetsParams
+		expectedEmotes     []EmoteWithOwner
 		respBody           string
 	}{
 		{
 			http.StatusBadRequest,
 			&Options{ClientID: "my-client-id"},
 			&GetEmoteSetsParams{EmoteSetIDs: nil},
+			nil,
 			`{"error":"Bad Request","status":400,"message":"The parameter \"emote_set_id\" was malformed: the value must be greater than or equal to 1"}`,
 		},
 		{
 			http.StatusOK,
 			&Options{ClientID: "my-client-id"},
 			&GetEmoteSetsParams{EmoteSetIDs: []string{"300678379"}},
+			[]EmoteWithOwner{
+				{
+					Emote: Emote{
+						ID:   "301147694",
+						Name: "sixone3SixDab",
+						Images: EmoteImage{
+							Url1x: "https://static-cdn.jtvnw.net/emoticons/v1/301147694/1.0",
+							Url2x: "https://static-cdn.jtvnw.net/emoticons/v1/301147694/2.0",
+							Url4x: "https://static-cdn.jtvnw.net/emoticons/v1//3.0",
+						},
+						Type:   "subscriptions",
+						Set_ID: "300678379",
+					},
+					OwnerID: "44931651",
+				},
+			},
 			`{"data":[{"id":"301147694","name":"sixone3SixDab","images":{"url_1x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/1.0","url_2x":"https://static-cdn.jtvnw.net/emoticons/v1/301147694/2.0","url_4x":"https://static-cdn.jtvnw.net/emoticons/v1//3.0"},"emote_type":"subscriptions","emote_set_id":"300678379","owner_id":"44931651"}]}`,
 		},
 	}
@@ -345,6 +363,17 @@ func TestGetEmoteSets(t *testing.T) {
 			}
 
 			continue
+		}
+
+		if len(resp.Data.Emotes) != len(testCase.expectedEmotes) {
+			t.Errorf("returned emotes were different lengths")
+		} else {
+			for i, expectedEmote := range testCase.expectedEmotes {
+				actualEmote := resp.Data.Emotes[i]
+				if expectedEmote != actualEmote {
+					t.Errorf("mismatching emotes %#v != %#v", expectedEmote, actualEmote)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
- `GetEmoteSets` now returns a `GetEmoteSetsResponse` instead of `GetChannelEmotesResponse`
- Ensure emotes are marshalled properly in `TestGetEmoteSets`

There's still a few ways you could chose to do the emote type - I went with a "parent" type EmoteWithOwner - let me know if you have another preference.

Unrelated to the PR but I noteiced while working on this - The naming of the `Set_ID` parameter seems out of place among all the other members. Would love to see that changed to `SetID` but I'll create an issue for it instead of rambling on in this PR.

Fixes #98 