### PR TITLE
HOTFIX: Hypetrain progress event unmarshal error struct 'EventSubContribution'

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -467,7 +467,7 @@ type EventSubContribution struct {
 	UserLogin string `json:"user_login"`
 	UserName  string `json:"user_name"`
 	Type      string `json:"type"`
-	Total     string `json:"total"`
+	Total     int64  `json:"total"`
 }
 
 // This belong to an outcome and defines user reward


### PR DESCRIPTION
The hype train progress event fails to unmarshal into helix's 
EventSubContribution struct as the 'Total' field is of type String 
when it should be of type integer.

- Change EventSubContribution.Total field to int64


`{
 "event": {
			"top_contributions": [{
				"user_id": "602005942",
				"user_login": "miguell0lxd",
				"user_name": "miguell0lxd",
				"type": "bits",
				"total": 4
			}, {
				"user_id": "616819305",
				"user_login": "le0n145",
				"user_name": "le0n145",
				"type": "subscription",
				"total": 1000
			}],
}`