### PR TITLE
HOTFIX: EventSub pagination

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -59,6 +59,8 @@ type EventSubSubscriptionsResponse struct {
 // Parameter for filtering subscriptions, currently only the status is filterable
 type EventSubSubscriptionsParams struct {
 	Status string `query:"status"`
+	Type   string `query:"type"`
+	After  string `query:"after"`
 }
 
 // Parameter for removing a subscription.


### PR DESCRIPTION
- add 'after' field to EventSubSubscriptionsParams struct
- add 'type' field to enable the ability to filter eventsubs by type i.e. 'channel.follow'