### PR TITLE
Corrected type of IsMature field on channe.update event

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -197,7 +197,7 @@ type EventSubChannelUpdateEvent struct {
 	Language             string `json:"language"`
 	CategoryID           string `json:"category_id"`
 	CategoryName         string `json:"category_name"`
-	IsMature             string `json:"is_mature"`
+	IsMature             bool   `json:"is_mature"`
 }
 
 // Data for a channel unban notification


### PR DESCRIPTION
I received this json unmarshal error while trying to parse a notification received from Twitch on the EventSub's `channel.update` event:

```
2021/08/27 19:20:41 [EventSub] Failed to unmarshal notification event: json: cannot unmarshal bool into Go struct field EventSubChannelUpdateEvent.is_mature of type string, data: {"broadcaster_user_id":"97916945","broadcaster_user_login":"heryin","broadcaster_user_name":"Heryin","title":"Testin again","language":"en","category_id":"509110","category_name":"Risk of Rain 2","is_mature":false}
```

Seems like returned `is_mature` is a boolean, according to the [EventSub documentation](https://dev.twitch.tv/docs/eventsub/eventsub-reference#channel-update-event).
