### PR TITLE
Client method "CheckUserSubsription" -> "CheckUserSubscription"

### DIFF
--- a/docs/subscriptions_docs.md
+++ b/docs/subscriptions_docs.md
@@ -36,7 +36,7 @@ if err != nil {
     // handle error
 }
 
-resp, err := client.CheckUserSubsription(&helix.UserSubscriptionsParams{
+resp, err := client.CheckUserSubscription(&helix.UserSubscriptionsParams{
     BroadcasterID: "29776980",
     UserID:        "145328278",
 })

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -77,10 +77,10 @@ func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsRe
 	return subscriptions, nil
 }
 
-// CheckUserSubsription Check if a specific user is subscribed to a specific channel
+// CheckUserSubscription Check if a specific user is subscribed to a specific channel
 //
 // Required scope: user:read:subscriptions
-func (c *Client) CheckUserSubsription(params *UserSubscriptionsParams) (*UserSubscriptionResponse, error) {
+func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams) (*UserSubscriptionResponse, error) {
 	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params)
 	if err != nil {
 		return nil, err

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -116,7 +116,7 @@ func TestChechUserSubscription(t *testing.T) {
 	for _, testCase := range testCases {
 		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
 
-		resp, err := c.CheckUserSubsription(&UserSubscriptionsParams{
+		resp, err := c.CheckUserSubscription(&UserSubscriptionsParams{
 			BroadcasterID: testCase.BroadcasterID,
 			UserID:        testCase.UserID,
 		})
@@ -154,7 +154,7 @@ func TestChechUserSubscription(t *testing.T) {
 		opts: options,
 	}
 
-	_, err := c.CheckUserSubsription(&UserSubscriptionsParams{})
+	_, err := c.CheckUserSubscription(&UserSubscriptionsParams{})
 	if err == nil {
 		t.Error("expected error but got nil")
 	}


### PR DESCRIPTION
Simple spelling mistake—you'll definitely want to merge this before you release v2, though =b