### PR TITLE
HOTFIX: ExtensionSetConfigurationParams Extension-ID json tag

### DIFF
--- a/extension_configuration.go
+++ b/extension_configuration.go
@@ -18,7 +18,7 @@ func (s ExtensionSegmentType) String() string {
 
 type ExtensionSetConfigurationParams struct {
 	Segment     ExtensionSegmentType `json:"segment"`
-	ExtensionID string               `json:"extension-id"`
+	ExtensionID string               `json:"extension_id"`
 	// BroadcasterID is only populated if segment is of type 'developer' || 'broadcaster'
 	BroadcasterID string `json:"broadcaster_id,omitempty"`
 	Version       string `json:"version"`


### PR DESCRIPTION
- fix this typo of using a '-' instead of '_' in the
ExtensionID field JSON tag for the ExtensionSetConfigurationParams struct