### PR TITLE
Fix prediction begin fields

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -327,7 +327,7 @@ type EventSubChannelPredictionBeginEvent struct {
 	Title                string            `json:"title"`
 	Outcomes             []EventSubOutcome `json:"outcomes"`
 	StartedAt            Time              `json:"started_at"`
-	LockedAt             Time              `json:"locked_at"`
+	LocksAt              Time              `json:"locks_at"`
 }
 
 // Data for a channel prediction progress event


### PR DESCRIPTION
As per https://dev.twitch.tv/docs/eventsub/eventsub-reference

The correct fields for the Begin and Progress events are "locks_at"

![image](https://user-images.githubusercontent.com/9765622/135537912-129855b2-dc82-4c16-baa9-0d49fb219fb6.png)

Side note: it would be cool if you would add hacktoberfest as a topic of your repo, if you don't mind obviously. 