### PR TITLE
feat(subscriptions): add new sub points field

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -29,6 +29,7 @@ type ManySubscriptions struct {
 	Subscriptions []Subscription `json:"data"`
 	Pagination    Pagination     `json:"pagination"`
 	Total         int            `json:"total"`
+	Points        int            `json:"points"`
 }
 
 type ManyUserSubscriptions struct {
@@ -73,6 +74,7 @@ func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsRe
 	subscriptions.Data.Subscriptions = resp.Data.(*ManySubscriptions).Subscriptions
 	subscriptions.Data.Pagination = resp.Data.(*ManySubscriptions).Pagination
 	subscriptions.Data.Total = resp.Data.(*ManySubscriptions).Total
+	subscriptions.Data.Points = resp.Data.(*ManySubscriptions).Points
 
 	return subscriptions, nil
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -29,7 +29,7 @@ type ManySubscriptions struct {
 	Subscriptions []Subscription `json:"data"`
 	Pagination    Pagination     `json:"pagination"`
 	Total         int            `json:"total"`
-	Points        int            `json:"points"`
+	Points        int            `json:"points"` // Each Tier 1 is worth 1, Tier 2 is worth 2, and Tier 3 is worth 6
 }
 
 type ManyUserSubscriptions struct {

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -20,7 +20,7 @@ func TestGetSubscriptions(t *testing.T) {
 			&Options{ClientID: "my-client-id", UserAccessToken: "my-access-token"},
 			"123",
 			[]string{},
-			`{"data": [{"broadcaster_id":"123","broadcaster_login":"test_user","broadcaster_name":"test_user","is_gift":true,"gifter_id":"456","gifter_login":"another_user","gifter_name":"Another_User","tier":"3000","plan_name":"The Ninjas","user_id":"123","user_id":"123","user_login":"test_user","user_name":"test_user"}],"pagination":{"cursor":"xxxx"},"total":1}`,
+			`{"data": [{"broadcaster_id":"123","broadcaster_login":"test_user","broadcaster_name":"test_user","is_gift":true,"gifter_id":"456","gifter_login":"another_user","gifter_name":"Another_User","tier":"3000","plan_name":"The Ninjas","user_id":"123","user_id":"123","user_login":"test_user","user_name":"test_user"}],"pagination":{"cursor":"xxxx"},"total":1,"points":6}`,
 		},
 		{
 			http.StatusBadRequest,
@@ -62,6 +62,10 @@ func TestGetSubscriptions(t *testing.T) {
 
 		if resp.Data.Total != 1 {
 			t.Errorf("expected total field to be 1 got %d", resp.Data.Total)
+		}
+
+		if resp.Data.Points != 6 {
+			t.Errorf("expected points field to be 6 got %d", resp.Data.Points)
 		}
 
 	}


### PR DESCRIPTION
2021‑10‑01: `Add the points field to the Get Broadcaster Subscriptions response. This field provides the current number of subscriber points earned by this broadcaster.` <https://dev.twitch.tv/docs/change-log>