### PR TITLE
Fix ChannelPointWon in prediction end eventsub event

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -477,7 +477,7 @@ type EventSubTopPredictor struct {
 	UserID            string `json:"user_id"`
 	UserLogin         string `json:"user_login"`
 	UserName          string `json:"user_name"`
-	ChannelPointWon   string `json:"channel_points_won"`
+	ChannelPointWon   int    `json:"channel_points_won"`
 	ChannelPointsUsed int    `json:"channel_points_used"`
 }
 


### PR DESCRIPTION
As per https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelpredictionend

ChannelPointWon is an int not a string