### PR TITLE
[WIP] Added arguments to all API calls that accepts auth options.

### DIFF
--- a/ads.go
+++ b/ads.go
@@ -35,8 +35,8 @@ type StartCommercialResponse struct {
 // StartCommercial starts a commercial on a specified channel
 // OAuth Token required
 // Requires channel:edit:commercial scope
-func (c *Client) StartCommercial(params *StartCommercialParams) (*StartCommercialResponse, error) {
-	resp, err := c.post("/channels/commercial", &ManyAdDetails{}, params)
+func (c *Client) StartCommercial(params *StartCommercialParams, opts ...Options) (*StartCommercialResponse, error) {
+	resp, err := c.post("/channels/commercial", &ManyAdDetails{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/analytics.go
+++ b/analytics.go
@@ -28,8 +28,8 @@ type ExtensionAnalyticsParams struct {
 
 // GetExtensionAnalytics returns a URL to the downloadable CSV file
 // containing analytics data. Valid for 5 minutes.
-func (c *Client) GetExtensionAnalytics(params *ExtensionAnalyticsParams) (*ExtensionAnalyticsResponse, error) {
-	resp, err := c.get("/analytics/extensions", &ManyExtensionAnalytics{}, params)
+func (c *Client) GetExtensionAnalytics(params *ExtensionAnalyticsParams, opts ...Options) (*ExtensionAnalyticsResponse, error) {
+	resp, err := c.get("/analytics/extensions", &ManyExtensionAnalytics{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +69,9 @@ type GameAnalyticsParams struct {
 
 // GetGameAnalytics returns a URL to the downloadable CSV file
 // containing analytics data for the specified game. Valid for 5 minutes.
-func (c *Client) GetGameAnalytics(params *GameAnalyticsParams) (*GameAnalyticsResponse, error) {
+func (c *Client) GetGameAnalytics(params *GameAnalyticsParams, opts ...Options) (*GameAnalyticsResponse, error) {
 
-	resp, err := c.get("/analytics/games", &ManyGameAnalytics{}, params)
+	resp, err := c.get("/analytics/games", &ManyGameAnalytics{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/bits.go
+++ b/bits.go
@@ -32,8 +32,8 @@ type BitsLeaderboardParams struct {
 // information for an authorized broadcaster.
 //
 // Required Scope: bits:read
-func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams) (*BitsLeaderboardResponse, error) {
-	resp, err := c.get("/bits/leaderboard", &ManyUserBitTotals{}, params)
+func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams, opts ...Options) (*BitsLeaderboardResponse, error) {
+	resp, err := c.get("/bits/leaderboard", &ManyUserBitTotals{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +96,8 @@ type CheermotesResponse struct {
 	Data ManyCheermotes
 }
 
-func (c *Client) GetCheermotes(params *CheermotesParams) (*CheermotesResponse, error) {
-	resp, err := c.get("/bits/cheermotes", &ManyCheermotes{}, params)
+func (c *Client) GetCheermotes(params *CheermotesParams, opts ...Options) (*CheermotesResponse, error) {
+	resp, err := c.get("/bits/cheermotes", &ManyCheermotes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels.go
+++ b/channels.go
@@ -37,8 +37,8 @@ type SearchChannelsResponse struct {
 
 // SearchChannels searches for Twitch channels based on the given search
 // parameters. Unlike GetStreams, this can also return offline channels.
-func (c *Client) SearchChannels(params *SearchChannelsParams) (*SearchChannelsResponse, error) {
-	resp, err := c.get("/search/channels", &ManySearchChannels{}, params)
+func (c *Client) SearchChannels(params *SearchChannelsParams, opts ...Options) (*SearchChannelsResponse, error) {
+	resp, err := c.get("/search/channels", &ManySearchChannels{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ type ChannelInformation struct {
 	Delay               int    `json:"delay"`
 }
 
-func (c *Client) GetChannelInformation(params *GetChannelInformationParams) (*GetChannelInformationResponse, error) {
-	resp, err := c.get("/channels", &ManyChannelInformation{}, params)
+func (c *Client) GetChannelInformation(params *GetChannelInformationParams, opts ...Options) (*GetChannelInformationResponse, error) {
+	resp, err := c.get("/channels", &ManyChannelInformation{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +101,8 @@ func (c *Client) GetChannelInformation(params *GetChannelInformationParams) (*Ge
 	return channels, nil
 }
 
-func (c *Client) EditChannelInformation(params *EditChannelInformationParams) (*EditChannelInformationResponse, error) {
-	resp, err := c.patchAsJSON("/channels", &EditChannelInformationResponse{}, params)
+func (c *Client) EditChannelInformation(params *EditChannelInformationParams, opts ...Options) (*EditChannelInformationResponse, error) {
+	resp, err := c.patchAsJSON("/channels", &EditChannelInformationResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_editors.go
+++ b/channels_editors.go
@@ -22,8 +22,8 @@ type ChannelEditorsResponse struct {
 
 // GetChannelEditors Get a list of users who have editor permissions for a specific channel
 // Required scope: channel:read:editors
-func (c *Client) GetChannelEditors(params *ChannelEditorsParams) (*ChannelEditorsResponse, error) {
-	resp, err := c.get("/channels/editors", &ManyChannelEditors{}, params)
+func (c *Client) GetChannelEditors(params *ChannelEditorsParams, opts ...Options) (*ChannelEditorsResponse, error) {
+	resp, err := c.get("/channels/editors", &ManyChannelEditors{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_points.go
+++ b/channels_points.go
@@ -87,8 +87,8 @@ type DeleteCustomRewardsResponse struct {
 
 // CreateCustomReward : Creates a Custom Reward on a channel.
 // Required scope: channel:manage:redemptions
-func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params)
+func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*Channe
 
 // DeleteCustomRewards : Deletes a Custom Rewards on a channel
 // Required scope: channel:manage:redemptions
-func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams) (*DeleteCustomRewardsResponse, error) {
-	resp, err := c.delete("/channel_points/custom_rewards", nil, params)
+func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams, opts ...Options) (*DeleteCustomRewardsResponse, error) {
+	resp, err := c.delete("/channel_points/custom_rewards", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +116,8 @@ func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams) (*Delete
 
 // GetCustomRewards : Get Custom Rewards on a channel
 // Required scope: channel:read:redemptions
-func (c *Client) GetCustomRewards(params *GetCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.get("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params)
+func (c *Client) GetCustomRewards(params *GetCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.get("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -25,8 +25,8 @@ type BadgeVersion struct {
 	ImageUrl4x string `json:"image_url_4x"`
 }
 
-func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams) (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges", &ManyChatBadge{}, params)
+func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams, opts ...Options) (*GetChatBadgeResponse, error) {
+	resp, err := c.get("/chat/badges", &ManyChatBadge{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams) (*GetChatBadge
 	return channels, nil
 }
 
-func (c *Client) GetGlobalChatBadges() (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges/global", &ManyChatBadge{}, nil)
+func (c *Client) GetGlobalChatBadges(opts ...Options) (*GetChatBadgeResponse, error) {
+	resp, err := c.get("/chat/badges/global", &ManyChatBadge{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ type EmoteImage struct {
 	Url4x string `json:"url_4x"`
 }
 
-func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams) (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes", &ManyEmotes{}, params)
+func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams, opts ...Options) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get("/chat/emotes", &ManyEmotes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +110,8 @@ func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams) (*GetChannelEm
 	return emotes, nil
 }
 
-func (c *Client) GetGlobalEmotes() (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes/global", &ManyEmotes{}, nil)
+func (c *Client) GetGlobalEmotes(opts ...Options) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get("/chat/emotes/global", &ManyEmotes{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -124,8 +124,8 @@ func (c *Client) GetGlobalEmotes() (*GetChannelEmotesResponse, error) {
 }
 
 // GetEmoteSets
-func (c *Client) GetEmoteSets(params *GetEmoteSetsParams) (*GetEmoteSetsResponse, error) {
-	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params)
+func (c *Client) GetEmoteSets(params *GetEmoteSetsParams, opts ...Options) (*GetEmoteSetsResponse, error) {
+	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/clips.go
+++ b/clips.go
@@ -43,8 +43,8 @@ type ClipsParams struct {
 }
 
 // GetClips returns information about a specified clip.
-func (c *Client) GetClips(params *ClipsParams) (*ClipsResponse, error) {
-	resp, err := c.get("/clips", &ManyClips{}, params)
+func (c *Client) GetClips(params *ClipsParams, opts ...Options) (*ClipsResponse, error) {
+	resp, err := c.get("/clips", &ManyClips{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ type CreateClipParams struct {
 // clip was not created and retry Create Clip.
 //
 // Required scope: clips:edit
-func (c *Client) CreateClip(params *CreateClipParams) (*CreateClipResponse, error) {
-	resp, err := c.post("/clips", &ManyClipEditURLs{}, params)
+func (c *Client) CreateClip(params *CreateClipParams, opts ...Options) (*CreateClipResponse, error) {
+	resp, err := c.post("/clips", &ManyClipEditURLs{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/drops.go
+++ b/drops.go
@@ -58,8 +58,8 @@ type UpdateDropsEntitlementsResponse struct {
 // Filtering by FulfillmentStatus returns all of the entitlements with the specified fulfillment status.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams) (*GetDropsEntitlementsResponse, error) {
-	resp, err := c.get("/entitlements/drops", &ManyEntitlementsWithPagination{}, params)
+func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams, opts ...Options) (*GetDropsEntitlementsResponse, error) {
+	resp, err := c.get("/entitlements/drops", &ManyEntitlementsWithPagination{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +81,8 @@ func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams) (*GetDr
 // operation should be retried again later.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) UpdateDropsEntitlements(params *UpdateDropsEntitlementsParams) (*UpdateDropsEntitlementsResponse, error) {
-	resp, err := c.patchAsJSON("/entitlements/drops", &ManyUpdatedEntitlementSet{}, params)
+func (c *Client) UpdateDropsEntitlements(params *UpdateDropsEntitlementsParams, opts ...Options) (*UpdateDropsEntitlementsResponse, error) {
+	resp, err := c.patchAsJSON("/entitlements/drops", &ManyUpdatedEntitlementSet{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_codes.go
+++ b/entitlement_codes.go
@@ -38,8 +38,8 @@ type CodeResponse struct {
 // Per https://dev.twitch.tv/docs/api/reference#get-code-status
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch as part of a contracted arrangement.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) GetEntitlementCodeStatus(params *CodesParams) (*CodeResponse, error) {
-	resp, err := c.get("/entitlements/codes", &ManyCodes{}, params)
+func (c *Client) GetEntitlementCodeStatus(params *CodesParams, opts ...Options) (*CodeResponse, error) {
+	resp, err := c.get("/entitlements/codes", &ManyCodes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +55,8 @@ func (c *Client) GetEntitlementCodeStatus(params *CodesParams) (*CodeResponse, e
 // Per https://dev.twitch.tv/docs/api/reference/#redeem-code
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) RedeemEntitlementCode(params *CodesParams) (*CodeResponse, error) {
-	resp, err := c.post("/entitlements/code", &ManyCodes{}, params)
+func (c *Client) RedeemEntitlementCode(params *CodesParams, opts ...Options) (*CodeResponse, error) {
+	resp, err := c.post("/entitlements/code", &ManyCodes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_grants.go
+++ b/entitlement_grants.go
@@ -22,13 +22,13 @@ type EntitlementsUploadResponse struct {
 // file and notify users that they have an entitlement. Entitlements are digital
 // items that users are entitled to use. Twitch entitlements are granted to users
 // gratis or as part of a purchase on Twitch.
-func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string) (*EntitlementsUploadResponse, error) {
+func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string, opts ...Options) (*EntitlementsUploadResponse, error) {
 	data := &entitlementUploadURLRequest{
 		ManifestID: manifestID,
 		Type:       entitlementType,
 	}
 
-	resp, err := c.post("/entitlements/upload", &ManyEntitlementsUploadURLs{}, data)
+	resp, err := c.post("/entitlements/upload", &ManyEntitlementsUploadURLs{}, data, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/eventsub.go
+++ b/eventsub.go
@@ -567,8 +567,8 @@ type EventSubChannelGoalEndEvent struct {
 }
 
 // Get all EventSub Subscriptions
-func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams) (*EventSubSubscriptionsResponse, error) {
-	resp, err := c.get("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params)
+func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams, opts ...Options) (*EventSubSubscriptionsResponse, error) {
+	resp, err := c.get("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -584,9 +584,9 @@ func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams) (
 }
 
 // Remove an EventSub Subscription
-func (c *Client) RemoveEventSubSubscription(id string) (*RemoveEventSubSubscriptionParamsResponse, error) {
+func (c *Client) RemoveEventSubSubscription(id string, opts ...Options) (*RemoveEventSubSubscriptionParamsResponse, error) {
 
-	resp, err := c.delete("/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id})
+	resp, err := c.delete("/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (c *Client) RemoveEventSubSubscription(id string) (*RemoveEventSubSubscript
 }
 
 // Creates an EventSub subscription
-func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription) (*EventSubSubscriptionsResponse, error) {
+func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription, opts ...Options) (*EventSubSubscriptionsResponse, error) {
 	if payload.Transport.Method == "webhook" && !strings.HasPrefix(payload.Transport.Callback, "https://") {
 		return nil, fmt.Errorf("error: callback must use https")
 	}
@@ -613,7 +613,7 @@ func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription) (*Eve
 	if callbackUrl.Port() != "" && callbackUrl.Port() != "443" {
 		return nil, fmt.Errorf("error: callback must use port 443")
 	}
-	resp, err := c.postAsJSON("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload)
+	resp, err := c.postAsJSON("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_configuration.go
+++ b/extension_configuration.go
@@ -63,7 +63,7 @@ type ExtensionSetConfigurationResponse struct {
 }
 
 // https://dev.twitch.tv/docs/extensions/reference/#set-extension-configuration-segment
-func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationParams) (*ExtensionSetConfigurationResponse, error) {
+func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationParams, opts ...Options) (*ExtensionSetConfigurationResponse, error) {
 	if params.BroadcasterID != "" {
 		switch params.Segment {
 		case ExtensionConfigurationDeveloperSegment, ExtensionConfigrationBroadcasterSegment:
@@ -72,7 +72,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 		}
 	}
 
-	resp, err := c.putAsJSON("/extensions/configurations", &ManyPolls{}, params)
+	resp, err := c.putAsJSON("/extensions/configurations", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 	return setExtCnfgResp, nil
 }
 
-func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurationParams) (*ExtensionGetConfigurationSegmentResponse, error) {
+func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurationParams, opts ...Options) (*ExtensionGetConfigurationSegmentResponse, error) {
 
 	if params.BroadcasterID != "" {
 		for _, segment := range params.Segments {
@@ -95,7 +95,7 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 		}
 	}
 
-	resp, err := c.get("/extensions/configurations", &ManyExtensionConfigurationSegments{}, params)
+	resp, err := c.get("/extensions/configurations", &ManyExtensionConfigurationSegments{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +107,9 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 	return extCfgSegResp, nil
 }
 
-func (c *Client) SetExtensionRequiredConfiguration(params *ExtensionSetRequiredConfigurationParams) (*ExtensionSetRequiredConfigurationResponse, error) {
+func (c *Client) SetExtensionRequiredConfiguration(params *ExtensionSetRequiredConfigurationParams, opts ...Options) (*ExtensionSetRequiredConfigurationResponse, error) {
 
-	resp, err := c.putAsJSON("/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params)
+	resp, err := c.putAsJSON("/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_pubsub.go
+++ b/extension_pubsub.go
@@ -61,8 +61,8 @@ type ExtensionSendPubSubMessageResponse struct {
 	ResponseCommon
 }
 
-func (c *Client) SendExtensionPubSubMessage(params *ExtensionSendPubSubMessageParams) (*ExtensionSendPubSubMessageResponse, error) {
-	resp, err := c.postAsJSON("/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params)
+func (c *Client) SendExtensionPubSubMessage(params *ExtensionSendPubSubMessageParams, opts ...Options) (*ExtensionSendPubSubMessageResponse, error) {
+	resp, err := c.postAsJSON("/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_secrets.go
+++ b/extension_secrets.go
@@ -39,8 +39,8 @@ type GetExtensionSecretParams struct {
 	ExtensionID string `query:"extension_id"`
 }
 
-func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams) (*ExtensionSecretCreationResponse, error) {
-	resp, err := c.post("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params)
+func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams, opts ...Options) (*ExtensionSecretCreationResponse, error) {
+	resp, err := c.post("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams) (*
 	return events, nil
 }
 
-func (c *Client) GetExtensionSecrets(params *GetExtensionSecretParams) (*GetExtensionSecretResponse, error) {
-	resp, err := c.postAsJSON("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params)
+func (c *Client) GetExtensionSecrets(params *GetExtensionSecretParams, opts ...Options) (*GetExtensionSecretResponse, error) {
+	resp, err := c.postAsJSON("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions.go
+++ b/extensions.go
@@ -59,8 +59,8 @@ type ExtensionSendChatMessageResponse struct {
 // exchanging Bits for an in-Extension digital good.
 //
 // See https://dev.twitch.tv/docs/api/reference/#get-extension-transactions
-func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams) (*ExtensionTransactionsResponse, error) {
-	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params)
+func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams, opts ...Options) (*ExtensionTransactionsResponse, error) {
+	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams) (
 // The author of the message is the Extension name.
 //
 // see https://dev.twitch.tv/docs/api/reference#send-extension-chat-message
-func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams) (*ExtensionSendChatMessageResponse, error) {
+func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams, opts ...Options) (*ExtensionSendChatMessageResponse, error) {
 
 	if len(params.Text) > 280 {
 		return nil, fmt.Errorf("error: chat message length exceeds 280 characters")
@@ -87,7 +87,7 @@ func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams
 		return nil, fmt.Errorf("error: broadcaster ID must be specified")
 	}
 
-	resp, err := c.postAsJSON("/extensions/chat", &ExtensionSendChatMessageResponse{}, params)
+	resp, err := c.postAsJSON("/extensions/chat", &ExtensionSendChatMessageResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/games.go
+++ b/games.go
@@ -20,8 +20,8 @@ type GamesParams struct {
 	Names []string `query:"name"` // Limit 100
 }
 
-func (c *Client) GetGames(params *GamesParams) (*GamesResponse, error) {
-	resp, err := c.get("/games", &ManyGames{}, params)
+func (c *Client) GetGames(params *GamesParams, opts ...Options) (*GamesResponse, error) {
+	resp, err := c.get("/games", &ManyGames{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +49,8 @@ type TopGamesResponse struct {
 	Data ManyGamesWithPagination
 }
 
-func (c *Client) GetTopGames(params *TopGamesParams) (*TopGamesResponse, error) {
-	resp, err := c.get("/games/top", &ManyGamesWithPagination{}, params)
+func (c *Client) GetTopGames(params *TopGamesParams, opts ...Options) (*TopGamesResponse, error) {
+	resp, err := c.get("/games/top", &ManyGamesWithPagination{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/goals.go
+++ b/goals.go
@@ -27,8 +27,8 @@ type GetCreatorGoalsParams struct {
 }
 
 // Required scope: channel:read:goals
-func (c *Client) GetCreatorGoals(payload *GetCreatorGoalsParams) (*CreatorGoalsResponse, error) {
-	resp, err := c.get("/goals", &ManyGoals{}, payload)
+func (c *Client) GetCreatorGoals(payload *GetCreatorGoalsParams, opts ...Options) (*CreatorGoalsResponse, error) {
+	resp, err := c.get("/goals", &ManyGoals{}, payload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/hype_train.go
+++ b/hype_train.go
@@ -45,8 +45,8 @@ type HypeTrainEventsParams struct {
 }
 
 // Required scope: channel:read:hype_train
-func (c *Client) GetHypeTrainEvents(params *HypeTrainEventsParams) (*HypeTrainEventsResponse, error) {
-	resp, err := c.get("/hypetrain/events", &ManyHypeTrainEvents{}, params)
+func (c *Client) GetHypeTrainEvents(params *HypeTrainEventsParams, opts ...Options) (*HypeTrainEventsResponse, error) {
+	resp, err := c.get("/hypetrain/events", &ManyHypeTrainEvents{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation.go
+++ b/moderation.go
@@ -29,8 +29,8 @@ type BannedUsersParams struct {
 // GetBannedUsers returns all banned and timed-out users in a channel.
 //
 // Required scope: moderation:read
-func (c *Client) GetBannedUsers(params *BannedUsersParams) (*BannedUsersResponse, error) {
-	resp, err := c.get("/moderation/banned", &ManyBans{}, params)
+func (c *Client) GetBannedUsers(params *BannedUsersParams, opts ...Options) (*BannedUsersResponse, error) {
+	resp, err := c.get("/moderation/banned", &ManyBans{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation_automod.go
+++ b/moderation_automod.go
@@ -11,8 +11,8 @@ type HeldMessageModerationParams struct {
 }
 
 // Required scope: moderator:manage:automod
-func (c *Client) ModerateHeldMessage(params *HeldMessageModerationParams) (*HeldMessageModerationResponse, error) {
-	resp, err := c.postAsJSON("/moderation/automod/message", nil, params)
+func (c *Client) ModerateHeldMessage(params *HeldMessageModerationParams, opts ...Options) (*HeldMessageModerationResponse, error) {
+	resp, err := c.postAsJSON("/moderation/automod/message", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/polls.go
+++ b/polls.go
@@ -48,8 +48,8 @@ type GetPollsResponse struct {
 }
 
 // Required scope: channel:read:polls
-func (c *Client) GetPolls(params *PollsParams) (*PollsResponse, error) {
-	resp, err := c.get("/polls", &ManyPolls{}, params)
+func (c *Client) GetPolls(params *PollsParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.get("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +78,8 @@ type PollChoiceParam struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) CreatePoll(params *CreatePollParams) (*PollsResponse, error) {
-	resp, err := c.postAsJSON("/polls", &ManyPolls{}, params)
+func (c *Client) CreatePoll(params *CreatePollParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.postAsJSON("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +99,8 @@ type EndPollParams struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) EndPoll(params *EndPollParams) (*PollsResponse, error) {
-	resp, err := c.patchAsJSON("/polls", &ManyPolls{}, params)
+func (c *Client) EndPoll(params *EndPollParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.patchAsJSON("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/predictions.go
+++ b/predictions.go
@@ -56,8 +56,8 @@ type GetPredictionsResponse struct {
 }
 
 // Required scope: channel:read:predictions
-func (c *Client) GetPredictions(params *PredictionsParams) (*PredictionsResponse, error) {
-	resp, err := c.get("/predictions", &ManyPredictions{}, params)
+func (c *Client) GetPredictions(params *PredictionsParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.get("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ type PredictionChoiceParam struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) CreatePrediction(params *CreatePredictionParams) (*PredictionsResponse, error) {
-	resp, err := c.postAsJSON("/predictions", &ManyPredictions{}, params)
+func (c *Client) CreatePrediction(params *CreatePredictionParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.postAsJSON("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +104,8 @@ type EndPredictionParams struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) EndPrediction(params *EndPredictionParams) (*PredictionsResponse, error) {
-	resp, err := c.patchAsJSON("/predictions", &ManyPredictions{}, params)
+func (c *Client) EndPrediction(params *EndPredictionParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.patchAsJSON("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/stream_markers.go
+++ b/stream_markers.go
@@ -49,8 +49,8 @@ type StreamMarkersParams struct {
 // of an user being recorded as VOD.
 //
 // Required Scope: user:read:broadcast
-func (c *Client) GetStreamMarkers(params *StreamMarkersParams) (*StreamMarkersResponse, error) {
-	resp, err := c.get("/streams/markers", &ManyStreamMarkers{}, params)
+func (c *Client) GetStreamMarkers(params *StreamMarkersParams, opts ...Options) (*StreamMarkersResponse, error) {
+	resp, err := c.get("/streams/markers", &ManyStreamMarkers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ type CreateStreamMarkerParams struct {
 // https://dev.twitch.tv/docs/api/reference/#create-stream-marker
 //
 // Required Scope: user:edit:broadcast
-func (c *Client) CreateStreamMarker(params *CreateStreamMarkerParams) (*CreateStreamMarkerResponse, error) {
-	resp, err := c.post("/streams/markers", &ManyCreateStreamMarkers{}, params)
+func (c *Client) CreateStreamMarker(params *CreateStreamMarkerParams, opts ...Options) (*CreateStreamMarkerResponse, error) {
+	resp, err := c.post("/streams/markers", &ManyCreateStreamMarkers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/streams.go
+++ b/streams.go
@@ -42,8 +42,8 @@ type StreamsParams struct {
 
 // GetStreams returns a list of live channels based on the search parameters.
 // To query offline channels, use SearchChannels.
-func (c *Client) GetStreams(params *StreamsParams) (*StreamsResponse, error) {
-	resp, err := c.get("/streams", &ManyStreams{}, params)
+func (c *Client) GetStreams(params *StreamsParams, opts ...Options) (*StreamsResponse, error) {
+	resp, err := c.get("/streams", &ManyStreams{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +69,8 @@ type FollowedStreamsParams struct {
 // may be duplicate or missing streams, as viewers join and leave streams.
 //
 // Required scope: user:read:follows
-func (c *Client) GetFollowedStream(params *FollowedStreamsParams) (*StreamsResponse, error) {
-	resp, err := c.get("/streams/followed", &ManyStreams{}, params)
+func (c *Client) GetFollowedStream(params *FollowedStreamsParams, opts ...Options) (*StreamsResponse, error) {
+	resp, err := c.get("/streams/followed", &ManyStreams{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -63,8 +63,8 @@ type UserSubscriptionsParams struct {
 // Broadcasters can only request their own subscriptions.
 //
 // Required scope: channel:read:subscriptions
-func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsResponse, error) {
-	resp, err := c.get("/subscriptions", &ManySubscriptions{}, params)
+func (c *Client) GetSubscriptions(params *SubscriptionsParams, opts ...Options) (*SubscriptionsResponse, error) {
+	resp, err := c.get("/subscriptions", &ManySubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsRe
 // CheckUserSubscription Check if a specific user is subscribed to a specific channel
 //
 // Required scope: user:read:subscriptions
-func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams) (*UserSubscriptionResponse, error) {
-	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params)
+func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams, opts ...Options) (*UserSubscriptionResponse, error) {
+	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/user_extensions.go
+++ b/user_extensions.go
@@ -21,8 +21,8 @@ type UserExtensionsResponse struct {
 // identified by a Bearer token
 //
 // Required scope: user:read:broadcast
-func (c *Client) GetUserExtensions() (*UserExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions/list", &ManyUserExtensions{}, nil)
+func (c *Client) GetUserExtensions(opts ...Options) (*UserExtensionsResponse, error) {
+	resp, err := c.get("/users/extensions/list", &ManyUserExtensions{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ type UserActiveExtensionsParams struct {
 // by a user ID or Bearer token.
 //
 // Optional scope: user:read:broadcast or user:edit:broadcast
-func (c *Client) GetUserActiveExtensions(params *UserActiveExtensionsParams) (*UserActiveExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions", &UserActiveExtensionSet{}, params)
+func (c *Client) GetUserActiveExtensions(params *UserActiveExtensionsParams, opts ...Options) (*UserActiveExtensionsResponse, error) {
+	resp, err := c.get("/users/extensions", &UserActiveExtensionSet{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +93,9 @@ type wrappedUpdateUserExtensionsPayload struct {
 // If you try to activate a given extension under multiple extension types, the last write wins (and there is no guarantee of write order).
 //
 // Required scope: user:edit:broadcast
-func (c *Client) UpdateUserExtensions(payload *UpdateUserExtensionsPayload) (*UserActiveExtensionsResponse, error) {
+func (c *Client) UpdateUserExtensions(payload *UpdateUserExtensionsPayload, opts ...Options) (*UserActiveExtensionsResponse, error) {
 	normalizedPayload := &wrappedUpdateUserExtensionsPayload{UpdateUserExtensionsPayload: *payload}
-	resp, err := c.putAsJSON("/users/extensions", &UserActiveExtensionSet{}, normalizedPayload)
+	resp, err := c.putAsJSON("/users/extensions", &UserActiveExtensionSet{}, normalizedPayload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -35,8 +35,8 @@ type UsersParams struct {
 // a user ID nor a login name is specified, the user is looked up by Bearer token.
 //
 // Optional scope: user:read:email
-func (c *Client) GetUsers(params *UsersParams) (*UsersResponse, error) {
-	resp, err := c.get("/users", &ManyUsers{}, params)
+func (c *Client) GetUsers(params *UsersParams, opts ...Options) (*UsersResponse, error) {
+	resp, err := c.get("/users", &ManyUsers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ type UpdateUserParams struct {
 // by a Bearer token.
 //
 // Required scope: user:edit
-func (c *Client) UpdateUser(params *UpdateUserParams) (*UsersResponse, error) {
-	resp, err := c.put("/users", &ManyUsers{}, params)
+func (c *Client) UpdateUser(params *UpdateUserParams, opts ...Options) (*UsersResponse, error) {
+	resp, err := c.put("/users", &ManyUsers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ type UsersFollowsParams struct {
 // Information returned is sorted in order, most recent follow first. This can return
 // information like “who is lirik following,” “who is following lirik,” or “is user X
 // following user Y.”
-func (c *Client) GetUsersFollows(params *UsersFollowsParams) (*UsersFollowsResponse, error) {
-	resp, err := c.get("/users/follows", &ManyFollows{}, params)
+func (c *Client) GetUsersFollows(params *UsersFollowsParams, opts ...Options) (*UsersFollowsResponse, error) {
+	resp, err := c.get("/users/follows", &ManyFollows{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +140,8 @@ type UsersBlockedParams struct {
 // GetUsersBlocked : Gets a specified user’s block list.
 //
 // Required scope: user:read:blocked_users
-func (c *Client) GetUsersBlocked(params *UsersBlockedParams) (*UsersBlockedResponse, error) {
-	resp, err := c.get("/users/blocks", &ManyUsersBlocked{}, params)
+func (c *Client) GetUsersBlocked(params *UsersBlockedParams, opts ...Options) (*UsersBlockedResponse, error) {
+	resp, err := c.get("/users/blocks", &ManyUsersBlocked{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ type BlockUserParams struct {
 // BlockUser : Blocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) BlockUser(params *BlockUserParams) (*BlockUserResponse, error) {
-	resp, err := c.put("/users/blocks", nil, params)
+func (c *Client) BlockUser(params *BlockUserParams, opts ...Options) (*BlockUserResponse, error) {
+	resp, err := c.put("/users/blocks", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +186,8 @@ type UnblockUserParams struct {
 // UnblockUser : Unblocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) UnblockUser(params *UnblockUserParams) (*BlockUserResponse, error) {
-	resp, err := c.delete("/users/blocks", nil, params)
+func (c *Client) UnblockUser(params *UnblockUserParams, opts ...Options) (*BlockUserResponse, error) {
+	resp, err := c.delete("/users/blocks", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/videos.go
+++ b/videos.go
@@ -60,8 +60,8 @@ type DeleteVideosResponse struct {
 
 // GetVideos gets video information by video ID (one or more), user ID (one only),
 // or game ID (one only).
-func (c *Client) GetVideos(params *VideosParams) (*VideosResponse, error) {
-	resp, err := c.get("/videos", &ManyVideos{}, params)
+func (c *Client) GetVideos(params *VideosParams, opts ...Options) (*VideosResponse, error) {
+	resp, err := c.get("/videos", &ManyVideos{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +76,8 @@ func (c *Client) GetVideos(params *VideosParams) (*VideosResponse, error) {
 
 // DeleteVideos delete one or more videos (max 5)
 // Required scope: channel:manage:videos
-func (c *Client) DeleteVideos(params *DeleteVideosParams) (*DeleteVideosResponse, error) {
-	resp, err := c.delete("/videos", &DeleteVideosResponse{}, params)
+func (c *Client) DeleteVideos(params *DeleteVideosParams, opts ...Options) (*DeleteVideosResponse, error) {
+	resp, err := c.delete("/videos", &DeleteVideosResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -29,8 +29,8 @@ type WebhookSubscriptionsParams struct {
 
 // GetWebhookSubscriptions gets webhook subscriptions, in order of expiration.
 // Requires an app access token.
-func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams) (*WebhookSubscriptionsResponse, error) {
-	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params)
+func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams, opts ...Options) (*WebhookSubscriptionsResponse, error) {
+	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ type WebhookSubscriptionPayload struct {
 	Secret       string `json:"hub.secret,omitempty"`
 }
 
-func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload) (*WebhookSubscriptionResponse, error) {
-	resp, err := c.postAsJSON("/webhooks/hub", nil, payload)
+func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload, opts ...Options) (*WebhookSubscriptionResponse, error) {
+	resp, err := c.postAsJSON("/webhooks/hub", nil, payload, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This CL adds an optional parameter to all API calls that allows the user to specific authentication parameters on a per-call basis. When authentication parameters are passed in, the authentication parameters in the client it self are ignored.

The rational for this change is described in #128 -- without the ability to handle auth state outside of the client, a user must instantiate and keep track of multiple copies of a client to achieve a high degree of parallelism using this library.