### PR TITLE
Fix field name in channel.subscription.message payload

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -173,7 +173,7 @@ type EventSubChannelSubscriptionMessageEvent struct {
 	BroadcasterUserName  string          `json:"broadcaster_user_name"`
 	Tier                 string          `json:"tier"`
 	Message              EventSubMessage `json:"message"`
-	CumulativeTotal      int             `json:"cumulative_total"`
+	CumulativeMonths     int             `json:"cumulative_months"`
 	StreakMonths         int             `json:"streak_months"`
 	DurationMonths       int             `json:"duration_months"`
 }


### PR DESCRIPTION
According to [twitch docs](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#channel-subscription-message-event), the cumulative months field in `channel.subscription.message` is `cumulative_months`, not `cumulative_total`