### PR TITLE
Add "total" field to ManyEventSubSubscriptions

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -44,6 +44,7 @@ type EventSubTransport struct {
 
 // Twitch Response for getting all current subscriptions
 type ManyEventSubSubscriptions struct {
+	Total                 int                    `json:"total"`
 	TotalCost             int                    `json:"total_cost"`
 	MaxTotalCost          int                    `json:"max_total_cost"`
 	EventSubSubscriptions []EventSubSubscription `json:"data"`


### PR DESCRIPTION
This PR adds the `total` field to the responses for `CreateEventSubSubscription` and `GetEventSubSubscriptions`, representing the total number of EventSub subscriptions created by a client.

Docs:
- https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
- https://dev.twitch.tv/docs/api/reference#get-eventsub-subscriptions