### PR TITLE
feat: Charity Campaign donation event - Campaign ID

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -576,7 +576,7 @@ type EventSubCharityAmount struct {
 }
 
 type EventSubCharityDonationEvent struct {
-	ID                   string                `json:"id"`
+	CharityCampaignID    string                `json:"charity_campaign"`
 	BroadcasterUserID    string                `json:"broadcaster_user_id"`
 	BroadcasterUserName  string                `json:"broadcaster_user_name"`
 	BroadcasterUserLogin string                `json:"broadcaster_user_login"`


### PR DESCRIPTION
Twitch have updated the charity donation event with a more relevant json field name 
for the charity campaign ID per request of my issue raised.

https://github.com/twitchdev/issues/issues/646