### PR TITLE
Update list of supported endpoints

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -26,11 +26,18 @@
 - [x] Get Channel Information
 - [x] Modify Channel Information
 - [x] Get Channel Editors
+- [ ] Get Charity Campaign
+- [ ] Get Chatters
 - [x] Get Channel Emotes
 - [x] Get Global Emotes
 - [x] Get Emote Sets
 - [x] Get Channel Chat Badges
 - [x] Get Global Chat Badges
+- [ ] Get Chat Settings
+- [ ] Update Chat Settings
+- [ ] Send Chat Announcement
+- [ ] Get User Chat Color
+- [ ] Update User Chat Color
 - [x] Create Clip
 - [x] Get Clips
 - [x] Get Code Status
@@ -49,21 +56,43 @@
 - [x] Get Extension Secrets
 - [x] Create Extension Secret
 - [x] Send Extension Chat Message
+- [ ] Get Extensions
+- [ ] Get Released Extensions
+- [ ] Get Extension Bits Products
+- [ ] Update Extension Bits Product
 - [x] Get Top Games
 - [x] Get Games
+- [ ] Get Creator Goals
 - [x] Get Hype Train Events
 - [ ] Check AutoMod Status
 - [x] Manage Held AutoMod Messages
+- [ ] Get AutoMod Settings
+- [ ] Update AutoMod Settings
 - [ ] Get Banned Events
 - [x] Get Banned Users
+- [ ] Ban User
+- [ ] Unban User
+- [ ] Get Blocked Terms
+- [ ] Add Blocked Term
+- [ ] Remove Blocked Term
+- [ ] Delete Chat Messages
 - [ ] Get Moderators
 - [ ] Get Moderator Events
+- [ ] Remove Channel Moderator
+- [ ] Get VIPs
+- [ ] Add Channel VIP
+- [ ] Remove Channel VIP
+- [ ] Get Soundtrack Current Track
+- [ ] Get Soundtrack Playlist
+- [ ] Get Soundtrack Playlists
 - [x] Get Polls
 - [x] Create Poll
 - [x] End Poll
 - [x] Get Predictions
 - [x] Create Prediction
 - [x] End Prediction
+- [ ] Start a raid
+- [ ] Cancel a raid
 - [ ] Get Channel Stream Schedule
 - [ ] Get Channel iCalendar
 - [ ] Update Channel Stream Schedule
@@ -95,4 +124,5 @@
 - [ ] Update User Extensions
 - [x] Get Videos
 - [x] Delete Videos
+- [ ] Send Whisper
 - [x] Get Webhook Subscriptions

--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -17,29 +17,38 @@
 - [x] Get Bits Leaderboard
 - [x] Get Cheermotes
 - [x] Get Extension Transactions
-- [x] Get Channel Information
-- [x] Modify Channel Information
-- [x] Get Channel Editors
 - [x] Create Custom Rewards
 - [x] Delete Custom Reward
 - [x] Get Custom Reward
 - [ ] Get Custom Reward Redemption
 - [ ] Update Custom Reward
 - [ ] Update Redemption Status
+- [x] Get Channel Information
+- [x] Modify Channel Information
+- [x] Get Channel Editors
 - [x] Get Channel Emotes
 - [x] Get Global Emotes
 - [x] Get Emote Sets
 - [x] Get Channel Chat Badges
 - [x] Get Global Chat Badges
 - [x] Create Clip
-- [x] Get Clip
 - [x] Get Clips
-- [x] Create Entitlement Grants Upload URL
 - [x] Get Code Status
 - [x] Get Drops Entitlements
 - [ ] Update Drops Entitlements
+- [x] Create Entitlement Grants Upload URL
 - [x] Redeem Code
-- [x] Create / Remove / List EventSub Subscriptions
+- [x] Create EventSub Subscription
+- [x] Delete EventSub Subscription
+- [x] Get EventSub Subscriptions
+- [x] Get Extension Configuration Segment
+- [x] Set Extension Configuration Segment
+- [x] Set Extension Required Configuration
+- [x] Send Extension PubSub Message
+- [x] Get Extension Live Channels
+- [x] Get Extension Secrets
+- [x] Create Extension Secret
+- [x] Send Extension Chat Message
 - [x] Get Top Games
 - [x] Get Games
 - [x] Get Hype Train Events
@@ -80,20 +89,10 @@
 - [x] Get Users Follows
 - [x] Get User Block List
 - [x] Block User
-- [x] UnBlock User
+- [x] Unblock User
 - [ ] Get User Extensions
 - [ ] Get User Active Extensions
 - [ ] Update User Extensions
 - [x] Get Videos
 - [x] Delete Videos
 - [x] Get Webhook Subscriptions
-- [x] Create Extension Secret
-- [x] Get Extension Secret
-- [ ] Revoke Extension Secrets
-- [x] Get Live Channels with Extension Activated
-- [x] Set Extension Required Configuration
-- [x] Set Extension Configuration Segment
-- [ ] Get Extension Channel Configuration
-- [x] Get Extension Configuration Segment
-- [x] Send Extension PubSub Message
-- [x] Send Extension Chat Message


### PR DESCRIPTION
The list of supported endpoints is incompleted compared to the [Twitch Helix API Reference](https://dev.twitch.tv/docs/api/reference)

Some supported endpoints have been renamed to match the Helix endpoint better, some have been sorted by category & endpoint name to fit the Helix reference better

The list of endpoints were generated auotmatically with some scraping from my [helix-api-list](https://github.com/pajlads/helix-api-list) repo:
```sh
./main.py | jq -r '. | sort_by(.category)[] | "- [ ] "+.name'
```
and then manually diffing the current list to find typos and things that (in my opinion) were not sorted properly. The new sorting follows Twitch's sorting almost completely, except Twitch puts the "Music" category in the middle instead of alphabetically as the other categories

Let me know if this PR does too many things, or does things it should do (like sorting/renaming things) and I can redo it without much effort.

The reason for this update is mainly because my own projects are starting to migrate from IRC commands to Helix APIs so having a good reference of what needs to be contributed to the repo is handy
