### PR TITLE
Fix BanUser request

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -52,7 +52,7 @@ type BanUserParams struct {
 }
 
 type BanUserRequestBody struct {
-	Duration int    `json:"duration"` // optional
+	Duration int    `json:"duration,omitempty"` // optional
 	Reason   string `json:"reason"`   // required
 	UserId   string `json:"user_id"`  // required
 }


### PR DESCRIPTION
https://dev.twitch.tv/docs/api/reference#ban-user

> To ban a user indefinitely, don’t include this field.

This is the justification for adding omitempty to the json tag.

>To put a user in a timeout, include this field and specify the timeout period, in seconds.
>The minimum timeout is 1 second and the maximum is 1,209,600 seconds (2 weeks).

By default the Duration would be 0, and this causes twitch to respond with "The value in the duration field is not valid."