### PR TITLE
Fix JSON tags for charity_campaign donation event

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -577,6 +577,8 @@ type EventSubCharityAmount struct {
 
 type EventSubCharityDonationEvent struct {
 	CharityCampaignID    string                `json:"campaign_id"`
+	CharityName          string                `json:"charity_name"`
+	CharityLogoURL       string                `json:"charity_logo"`
 	BroadcasterUserID    string                `json:"broadcaster_id"`
 	BroadcasterUserName  string                `json:"broadcaster_name"`
 	BroadcasterUserLogin string                `json:"broadcaster_login"`

--- a/eventsub.go
+++ b/eventsub.go
@@ -579,9 +579,9 @@ type EventSubCharityDonationEvent struct {
 	CharityCampaignID    string                `json:"campaign_id"`
 	CharityName          string                `json:"charity_name"`
 	CharityLogoURL       string                `json:"charity_logo"`
-	BroadcasterUserID    string                `json:"broadcaster_id"`
-	BroadcasterUserName  string                `json:"broadcaster_name"`
-	BroadcasterUserLogin string                `json:"broadcaster_login"`
+	BroadcasterUserID    string                `json:"broadcaster_user_id"`
+	BroadcasterUserName  string                `json:"broadcaster_user_name"`
+	BroadcasterUserLogin string                `json:"broadcaster_user_login"`
 	UserID               string                `json:"user_id"`
 	UserName             string                `json:"user_name"`
 	UserLogin            string                `json:"user_login"`


### PR DESCRIPTION
My previous PR #150 fixed the `value` and `campaign_id` fields for the donation event. It also changed the broadcaster related fields to what was described in the [documentation](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#charity-donation-event). 

The documentation is wrong and does not reflect what is actually provided from the live eventsub. 

I tested it now and [commented about it here](https://github.com/twitchdev/issues/issues/642#issuecomment-1295432538) to show what the event looks like today.

This PR fixes and now reflects what the live eventsub provides in the donation event. It also adds the newly provided fields `charity_name` and `charity_logo` (both are not shown in twitch's documentation).