### PR TITLE
fix: charity campaigns value json field

### DIFF
--- a/charity.go
+++ b/charity.go
@@ -25,7 +25,7 @@ type CharityDonationsResponse struct {
 }
 
 type CharityCampaignAmount struct {
-	Value         int64  `json:"amount"`
+	Value         int64  `json:"value"`
 	DecimalPlaces int64  `json:"decimal_places"`
 	Currency      string `json:"currency"`
 }


### PR DESCRIPTION
- use the correct json tag for the documented endpoint
- https://dev.twitch.tv/docs/api/reference#get-charity-campaign