### PR TITLE
Implement Get Chat Settings endpoint

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -33,7 +33,7 @@
 - [x] Get Emote Sets
 - [x] Get Channel Chat Badges
 - [x] Get Global Chat Badges
-- [ ] Get Chat Settings
+- [x] Get Chat Settings
 - [ ] Update Chat Settings
 - [ ] Send Chat Announcement
 - [ ] Get User Chat Color

--- a/docs/chat_docs.md
+++ b/docs/chat_docs.md
@@ -105,3 +105,26 @@ if err != nil {
 
 fmt.Printf("%+v\n", resp)
 ```
+
+## Get Chat Settings
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+    AppAccessToken: "your-app-user-token",
+    // Optionally, a moderator's user token with the `moderator:read:chat_settings` scope can be specified to read some more settings
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetChatSettings(&helix.GetChatSettingsParams{
+    BroadcasterID: "22484632",
+    // ModeratorID should be specified matching the UserAccessToken if you want the extended information
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```


### PR DESCRIPTION
This PR implements the `Get Chat Settings` endpoint

## Open questions

There are a few optional fields in the response.


### 1.
These fields are only included if a moderator with the correct scopes is sent along to the `moderator_id` request parameter
 - `moderator_id`
 - `non_moderator_chat_delay`
 - `non_moderator_chat_delay_duration`

Right now, these fields are not optional in the response struct, so instead of matching the response payload of null, they're set to their default values (so false, empty string, or 0).
While this is technically incorrect, using pointers for those 3 values might be less ergonomic so I leave that choice up to you.

I think these fields should be pointers.  
**Do you think the scope-locked fields should be pointers so users can know whether the fields were included?**

### 2.
These fields are only included if the matching `bool` field is set to true
 - `follower_mode_duration`
 - `slow_mode_wait_time`

These fields are also not pointers, so if follower mode is disabled, `follower_mode_duration` will be 0 while technically the response we got was null.

I think these should stay pointer-free.  
**Do you think the fields should be pointers?**
