### PR TITLE
Send BanUser broadcaster & moderator ID as query parameters

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -46,8 +46,8 @@ func (c *Client) GetBannedUsers(params *BannedUsersParams) (*BannedUsersResponse
 }
 
 type BanUserParams struct {
-	BroadcasterID string             `json:"broadcaster_id"`
-	ModeratorId   string             `json:"moderator_id"`
+	BroadcasterID string             `query:"broadcaster_id"`
+	ModeratorId   string             `query:"moderator_id"`
 	Body          BanUserRequestBody `json:"data"`
 }
 


### PR DESCRIPTION
While Twitch *currently* accepts broadcaster & moderator ID as JSON body
fields (without documenting they accept it), the documentation clearly
states they should be sent as query parameters

API reference: https://dev.twitch.tv/docs/api/reference/#ban-user

I confirm I have tested this code and can verify that bans & timeouts still work using this function.
