### PR TITLE
feat: Support for update custom reward redemption status

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -20,7 +20,7 @@
 - [x] Create Custom Rewards
 - [x] Delete Custom Reward
 - [x] Get Custom Reward
-- [x] Get Custom Reward Redemption
+- [ ] Get Custom Reward Redemption
 - [x] Update Custom Reward
 - [x] Update Redemption Status
 - [x] Get Channel Information

--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -20,9 +20,9 @@
 - [x] Create Custom Rewards
 - [x] Delete Custom Reward
 - [x] Get Custom Reward
-- [ ] Get Custom Reward Redemption
+- [x] Get Custom Reward Redemption
 - [x] Update Custom Reward
-- [ ] Update Redemption Status
+- [x] Update Redemption Status
 - [x] Get Channel Information
 - [x] Modify Channel Information
 - [x] Get Channel Editors

--- a/channels_points.go
+++ b/channels_points.go
@@ -1,7 +1,5 @@
 package helix
 
-import "time"
-
 type ChannelCustomRewardsParams struct {
 	BroadcasterID                     string `query:"broadcaster_id"`
 	Title                             string `json:"title"`
@@ -132,7 +130,7 @@ type ChannelCustomRewardsRedemption struct {
 	UserLogin        string              `json:"user_login"`
 	UserInput        string              `json:"user_input"`
 	Status           string              `json:"status"`
-	RedeemedAt       time.Time           `json:"redeemed_at"`
+	RedeemedAt       Time                `json:"redeemed_at"`
 	Reward           ChannelCustomReward `json:"reward"`
 }
 

--- a/channels_points.go
+++ b/channels_points.go
@@ -1,5 +1,7 @@
 package helix
 
+import "time"
+
 type ChannelCustomRewardsParams struct {
 	BroadcasterID                     string `query:"broadcaster_id"`
 	Title                             string `json:"title"`
@@ -104,6 +106,36 @@ type DeleteCustomRewardsResponse struct {
 	ResponseCommon
 }
 
+type UpdateChannelCustomRewardsRedemptionStatusParams struct {
+	ID            string `query:"id"`
+	BroadcasterID string `query:"broadcaster_id"`
+	RewardID      string `query:"reward_id"`
+	Status        string `json:"status"`
+}
+
+type ChannelCustomRewardsRedemptionResponse struct {
+	ResponseCommon
+	Data ManyChannelCustomRewardsRedemptions
+}
+
+type ManyChannelCustomRewardsRedemptions struct {
+	Redemptions []ChannelCustomRewardsRedemption `json:"data"`
+}
+
+type ChannelCustomRewardsRedemption struct {
+	ID               string              `json:"id"`
+	BroadcasterID    string              `json:"broadcaster_id"`
+	BroadcasterLogin string              `json:"broadcaster_login"`
+	BroadcasterName  string              `json:"broadcaster_name"`
+	UserID           string              `json:"user_id"`
+	UserName         string              `json:"user_name"`
+	UserLogin        string              `json:"user_login"`
+	UserInput        string              `json:"user_input"`
+	Status           string              `json:"status"`
+	RedeemedAt       time.Time           `json:"redeemed_at"`
+	Reward           ChannelCustomReward `json:"reward"`
+}
+
 // CreateCustomReward : Creates a Custom Reward on a channel.
 // Required scope: channel:manage:redemptions
 func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
@@ -161,4 +193,19 @@ func (c *Client) GetCustomRewards(params *GetCustomRewardsParams) (*ChannelCusto
 	rewards.Data.ChannelCustomRewards = resp.Data.(*ManyChannelCustomRewards).ChannelCustomRewards
 
 	return rewards, nil
+}
+
+// UpdateChannelCustomRewardsRedemptionStatus : Update a Custom Reward Redemption status on a channel.
+// Required scope: channel:manage:redemptions
+func (c *Client) UpdateChannelCustomRewardsRedemptionStatus(params *UpdateChannelCustomRewardsRedemptionStatusParams) (*ChannelCustomRewardsRedemptionResponse, error) {
+	resp, err := c.patchAsJSON("/channel_points/custom_rewards/redemptions", &ManyChannelCustomRewardsRedemptions{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	redemptions := &ChannelCustomRewardsRedemptionResponse{}
+	resp.HydrateResponseCommon(&redemptions.ResponseCommon)
+	redemptions.Data.Redemptions = resp.Data.(*ManyChannelCustomRewardsRedemptions).Redemptions
+
+	return redemptions, nil
 }

--- a/docs/channels_points_docs.md
+++ b/docs/channels_points_docs.md
@@ -93,3 +93,50 @@ if err != nil {
 
 fmt.Printf("%+v\n", resp)
 ```
+
+## Get Custom Reward Redemption Status
+
+This is an example of how to get the status of a custom reward redemption.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetCustomRewards(&helix.GetCustomRewardsParams{
+    BroadcasterID : "145328278",
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```
+
+## Update Custom Reward Redemption Status
+
+This is an example of how to update the status of a custom reward redemption.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.UpdateChannelCustomRewardsRedemptionStatus(&helix.UpdateChannelCustomRewardsRedemptionStatusParams{
+    ID            : "17fa2df1-ad76-4804-bfa5-a40ef63efe63",
+    BroadcasterID : "274637212",
+    RewardID      : "92af127c-7326-4483-a52b-b0da0be61c01",
+    Status        : "FULFILLED", // The only acceptable values are "CANCELED" and "FULFILLED"
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```


### PR DESCRIPTION
Thankful for the project, but it's missing this API that I need. I don't really know how to test it locally e2e so if you could explain that I can try it out. Otherwise, here you go. I just tried my best to follow the spec https://dev.twitch.tv/docs/api/reference/#update-redemption-status and the existing code/tests. Ran `go test ./... -cover` and it all passed. 