### PR TITLE
Fix editing of channel information

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -116,11 +116,11 @@ type GetChannelInformationParams struct {
 
 type EditChannelInformationParams struct {
 	BroadcasterID       string   `query:"broadcaster_id" json:"-"`
-	GameID              string   `json:"game_id"`
-	BroadcasterLanguage string   `json:"broadcaster_language"`
-	Title               string   `json:"title"`
+	GameID              string   `json:"game_id,omitempty"`
+	BroadcasterLanguage string   `json:"broadcaster_language,omitempty"`
+	Title               string   `json:"title,omitempty"`
 	Delay               int      `json:"delay,omitempty"`
-	Tags                []string `json:"tags"`
+	Tags                []string `json:"tags,omitempty"`
 }
 
 type GetChannelInformationResponse struct {


### PR DESCRIPTION
When we sending edit channel information, we can omit some fields, so twitch can correctly handle partial update. For example current behavior is to update title, we first need to get channel information to use `gameId` and use that info in request, otherwise it will set empty category, even we want to change only title.