### PR TITLE
Fix omitempty and add additional datetime fields

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -212,6 +212,10 @@ func buildQueryString(req *http.Request, v interface{}) (string, error) {
 
 			tag = tagSlice[0]
 			defaultValue = tagSlice[1]
+
+			if defaultValue == "omitempty" {
+				defaultValue = ""
+			}
 		}
 
 		if field.Type.Kind() == reflect.Slice {

--- a/time.go
+++ b/time.go
@@ -10,7 +10,14 @@ const (
 )
 
 var (
-	datetimeFields = []string{"started_at", "ended_at"}
+	datetimeFields = []string{
+		"started_at",
+		"start_time",
+		"vacation_start_time",
+		"vacation_end_time",
+		"ended_at",
+		"end_time",
+	}
 )
 
 // Time is our custom time struct.


### PR DESCRIPTION
Some date fields not being recognized as date fields, which have now been added to the datefields array.

Additionally I identified that some `query` fields are defining `omitempty` on them, which is resulting in a default of `omitempty` being sent to twitch.