### PR TITLE
Fix reflect tags for UpdateUserChatColorParams

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -393,8 +393,8 @@ type UpdateUserChatColorResponse struct {
 
 // UpdateUserChatColorParams are the parameters for UpdateUserChatColor
 type UpdateUserChatColorParams struct {
-	UserID string `json:"user_id"`
-	Color  string `json:"color"`
+	UserID string `query:"user_id"`
+	Color  string `query:"color"`
 }
 
 // UpdateUserChatcolor updates the color used for the user’s name in chat.


### PR DESCRIPTION
UpdateUserChatColor call does not work because the fields in UpdateUserChatColorParams are incorrectly marked as json, instead of query, so the query string comes out empty.