### PR TITLE
fix: change tag of GetScheduleParams to query for parameters to be added to a get call.

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -2,12 +2,12 @@ package helix
 
 // GetScheduleParams are the parameters for GetSchedule
 type GetScheduleParams struct {
-	BroadcasterID string `json:"broadcaster_id"`
-	ID            string `json:"id"`
-	StartTime     Time   `json:"start_time"`
-	UTCOffset     string `json:"utc_offset"`
-	First         int    `json:"first"`
-	After         string `json:"after"`
+	BroadcasterID string `query:"broadcaster_id"`
+	ID            string `query:"id"`
+	StartTime     Time   `query:"start_time"`
+	UTCOffset     string `query:"utc_offset"`
+	First         int    `query:"first"`
+	After         string `query:"after"`
 }
 
 // GetScheduleResponse is the response data in GetSchedule


### PR DESCRIPTION
Hi there,

I tried the GetSchedule call and while debugging it I found that the parameters do not get added to the GET query string in the URL. Comparing that with other parameters in the package, I found the issue to be the tag. It was set to JSON, thus not handled, when building a query string in the request.

I changed the tags of the struct to state "query" instead in order for them to be added to the query string, which should solve the issue.

Best
Rapix