### PR TITLE
Fix panic on token refresh failure

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -427,7 +427,13 @@ func (c *Client) canRefreshToken() bool {
 func (c *Client) refreshToken() error {
 	resp, err := c.RefreshUserAccessToken(c.opts.RefreshToken)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to refresh token: (%d: %s) %v", resp.StatusCode, resp.ErrorMessage, err)
+		statusCode := -1
+		var errorMessage string
+		if resp != nil {
+			statusCode = resp.StatusCode
+			errorMessage = resp.ErrorMessage
+		}
+		return fmt.Errorf("failed to refresh token: (%d: %s) %v", statusCode, errorMessage, err)
 	}
 
 	c.mu.Lock()

--- a/helix_test.go
+++ b/helix_test.go
@@ -741,7 +741,7 @@ func TestOnUserAccessTokenRefreshed(t *testing.T) {
 		t.Fatalf("Did not expect an error, got \"%s\"", err.Error())
 	}
 
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	if newAccessToken != wantNewAccessToken {
 		t.Errorf("expected newAccessToken to be %q, got %q", wantNewAccessToken, newAccessToken)


### PR DESCRIPTION
Fixes a panic when RefreshUserAccessToken returns a nil response.