### PR TITLE
fix: EventSubProduct Bits json tag key

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -513,7 +513,7 @@ type EventSubOutcome struct {
 
 type EventSubProduct struct {
 	Name          string `json:"name"`
-	Bits          int    `json:"bots"`
+	Bits          int    `json:"bits"`
 	Sku           string `json:"sku"`
 	InDevelopment bool   `json:"in_development"`
 }


### PR DESCRIPTION
- fix the ```EventSubProduct``` struct ```Bits``` json tag value to be ```bits```