### PR TITLE
fix: deprecate ioutil

### DIFF
--- a/docs/eventsub_docs.md
+++ b/docs/eventsub_docs.md
@@ -92,7 +92,7 @@ type eventSubNotification struct {
 }
 
 func eventsubFollow(w http.ResponseWriter, r *http.Request) {
-    body, err := ioutil.ReadAll(r.Body)
+    body, err := io.ReadAll(r.Body)
     if err != nil {
         log.Println(err)
         return

--- a/helix.go
+++ b/helix.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"reflect"
@@ -364,7 +364,7 @@ func (c *Client) doRequest(req *http.Request, resp *Response) error {
 
 		setResponseStatusCode(resp, "StatusCode", response.StatusCode)
 
-		bodyBytes, err := ioutil.ReadAll(response.Body)
+		bodyBytes, err := io.ReadAll(response.Body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This removes ioutil and replaces it with the io package since go decided to deprecate ioutil in favor of having an io and os package instead.