### PR TITLE
feat: Implement Get Moderated Channels endpoint

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -77,6 +77,7 @@
 - [x] Add Blocked Term
 - [x] Remove Blocked Term
 - [x] Delete Chat Messages
+- [x] Get Moderated Channels
 - [x] Get Moderators
 - [x] Add Channel Moderator
 - [x] Remove Channel Moderator

--- a/docs/moderation_docs.md
+++ b/docs/moderation_docs.md
@@ -288,3 +288,29 @@ if err != nil {
 
 fmt.Printf("%+v\n", resp)
 ```
+
+## Get Moderated Channels
+
+To use this function you need a user access token with the `user:read:moderated_channels` scope.
+`UserID` is required and must match the user ID of the user access token.
+
+This is an example of how to get channels the user has moderator privileges in.
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+    UserAccessToken: "your-user-access-token",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetModeratedChannels(&helix.GetModeratedChannelsParams{
+    UserID: "154315414",
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```


### PR DESCRIPTION
Adds `GetModeratedChannels` function. Its existence wasn't acknowledged in the supported endpoints document, but it's included as well as supported now.

I'm not sure if my tests are implemented correctly (but it passes), so bear with me!

https://dev.twitch.tv/docs/api/reference/#get-moderated-channels