### PR TITLE
Fix incorrect EventSubChannelChatMessageEvent parsing

### DIFF
--- a/eventsub.go
+++ b/eventsub.go
@@ -508,7 +508,7 @@ type EventSubChannelChatNotificationBitsBadgeTier struct {
 
 type EventSubChatNotificationMessage struct {
 	Text      string                        `json:"text"`
-	Fragments []EventSubChatMessageFragment `json:"fragment"`
+	Fragments []EventSubChatMessageFragment `json:"fragments"`
 }
 
 // Data for a channel poll begin event

--- a/eventsub.go
+++ b/eventsub.go
@@ -296,7 +296,7 @@ type EventSubChannelChatMessageEvent struct {
 
 type EventSubChatMessage struct {
 	Text      string                        `json:"text"`
-	Fragments []EventSubChatMessageFragment `json:"fragment"`
+	Fragments []EventSubChatMessageFragment `json:"fragments"`
 }
 
 type EventSubChatMessageReply struct {
@@ -354,10 +354,10 @@ type EventSubChatMessageCheermote struct {
 }
 
 type EventSubChatMessageEmote struct {
-	ID         string `json:"id"`
-	EmoteSetID string `json:"emote_set_id"`
-	OwnerID    string `json:"owner_id"`
-	Format     string `json:"format"`
+	ID         string   `json:"id"`
+	EmoteSetID string   `json:"emote_set_id"`
+	OwnerID    string   `json:"owner_id"`
+	Format     []string `json:"format"`
 }
 
 type EventSubChatMessageMention struct {


### PR DESCRIPTION
This should resolve #232.

None of the objects described in https://dev.twitch.tv/docs/eventsub/eventsub-reference/ refer to JSON field `fragment` but several refer to`fragments`.

`go test ./...` passes. `go vet ./...` is clean. There's some lint on `staticcheck` but nothing in the code touched by this PR.