### PR TITLE
feat: add support of `title` and `duration` to `CreateClip`

### DIFF
--- a/clips.go
+++ b/clips.go
@@ -85,10 +85,12 @@ func (ccr *CreateClipResponse) GetClipsCreationRateLimitRemaining() int {
 }
 
 type CreateClipParams struct {
+	// BroadcasterID The ID of the broadcaster whose stream you want to create a clip from.
 	BroadcasterID string `query:"broadcaster_id"`
-
-	// Optional
-	HasDelay bool `query:"has_delay,false"`
+	// Optional. The title of the clip.
+	Title string `query:"title"`
+	// Optional. The length of the clip in seconds. Possible values range from 5 to 60 inclusively with a precision of 0.1. The default is 30.
+	Duration float32 `query:"duration"`
 }
 
 // CreateClip creates a clip programmatically. This returns both an ID and

--- a/clips_test.go
+++ b/clips_test.go
@@ -123,6 +123,14 @@ func TestCreateClip(t *testing.T) {
 			"598",
 		},
 		{
+			http.StatusAccepted,
+			&Options{ClientID: "my-client-id"},
+			&CreateClipParams{BroadcasterID: "26490481", Title: "Title", Duration: 0.5}, // summit1g
+			`{"data":[{"id":"IronicHedonisticOryxSquadGoals","edit_url":"https://clips.twitch.tv/IronicHedonisticOryxSquadGoals/edit"}]}`,
+			"600",
+			"598",
+		},
+		{
 			http.StatusUnauthorized,
 			&Options{ClientID: "my-client-id"},
 			&CreateClipParams{BroadcasterID: "26490481"},                                 // summit1g


### PR DESCRIPTION
Also, there is no param like "hasdelay", so i removed that.

https://dev.twitch.tv/docs/api/reference/#create-clip