### PR TITLE
feat: Added `GetTeams` Method

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -111,7 +111,7 @@
 - [x] Get Broadcaster Subscriptions
 - [x] Check User Subscription
 - [ ] Get Channel Teams
-- [ ] Get Teams
+- [x] Get Teams
 - [x] Get Users
 - [x] Update User
 - [x] Get Users Follows

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Follow the links below to their respective API usage examples:
 - [Stream Markers](stream_markers_docs.md)
 - [Streams](streams_docs.md)
 - [Subscriptions](subscriptions_docs.md)
+- [Teams](teams_docs.md)
 - [User Extensions](user_extensions.md)
 - [Users](users_docs.md)
 - [Videos](videos_docs.md)

--- a/docs/teams_docs.md
+++ b/docs/teams_docs.md
@@ -1,0 +1,45 @@
+# Teams Documentation
+
+## Get Teams
+
+Gets information about the specified Twitch team. You can specify the team by its name or ID, but not both.
+
+### Get Team by Name
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetTeams(&helix.GetTeamsParams{
+    Name: "weightedblanket",
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```
+
+### Get Team by ID
+
+```go
+client, err := helix.NewClient(&helix.Options{
+    ClientID: "your-client-id",
+})
+if err != nil {
+    // handle error
+}
+
+resp, err := client.GetTeams(&helix.GetTeamsParams{
+    ID: "1234567",
+})
+if err != nil {
+    // handle error
+}
+
+fmt.Printf("%+v\n", resp)
+```

--- a/teams.go
+++ b/teams.go
@@ -1,0 +1,47 @@
+package helix
+
+type GetTeamsParams struct {
+	Name string `query:"name"`
+	ID   string `query:"id"`
+}
+
+type GetTeamsResponse struct {
+	ResponseCommon
+	Data ManyTeams
+}
+
+type ManyTeams struct {
+	Teams []Team `json:"data"`
+}
+
+type Team struct {
+	Users              []TeamUser `json:"users"`
+	BackgroundImageURL string     `json:"background_image_url"`
+	Banner             string     `json:"banner"`
+	CreatedAt          Time       `json:"created_at"`
+	UpdatedAt          Time       `json:"updated_at"`
+	Info               string     `json:"info"`
+	ThumbnailURL       string     `json:"thumbnail_url"`
+	TeamName           string     `json:"team_name"`
+	TeamDisplayName    string     `json:"team_display_name"`
+	ID                 string     `json:"id"`
+}
+
+type TeamUser struct {
+	UserID    string `json:"user_id"`
+	UserLogin string `json:"user_login"`
+	UserName  string `json:"user_name"`
+}
+
+func (c *Client) GetTeams(params *GetTeamsParams) (*GetTeamsResponse, error) {
+	resp, err := c.get("/teams", &ManyTeams{}, params)
+	if err != nil {
+		return nil, err
+	}
+
+	teams := &GetTeamsResponse{}
+	resp.HydrateResponseCommon(&teams.ResponseCommon)
+	teams.Data.Teams = resp.Data.(*ManyTeams).Teams
+
+	return teams, nil
+}

--- a/teams.go
+++ b/teams.go
@@ -33,6 +33,8 @@ type TeamUser struct {
 	UserName  string `json:"user_name"`
 }
 
+// GetTeams gets information about the specified Twitch team.
+// Specify the team using the name or ID parameter (but not both).
 func (c *Client) GetTeams(params *GetTeamsParams) (*GetTeamsResponse, error) {
 	resp, err := c.get("/teams", &ManyTeams{}, params)
 	if err != nil {

--- a/teams_test.go
+++ b/teams_test.go
@@ -1,0 +1,104 @@
+package helix
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetTeams(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode     int
+		options        *Options
+		GetTeamsParams *GetTeamsParams
+		respBody       string
+	}{
+		{
+			http.StatusBadRequest,
+			&Options{ClientID: "my-client-id"},
+			&GetTeamsParams{},
+			`{"error":"Bad Request","status":400,"message":"Must provide either team_id or team_name"}`,
+		},
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&GetTeamsParams{Name: "weightedblanket"},
+			`{"data":[{"users":[{"user_id":"278217731","user_login":"mastermndio","user_name":"MasterMndio"},{"user_id":"41284990","user_login":"jenninexus","user_name":"JenniNexus"}],"background_image_url":null,"banner":null,"created_at":"2020-02-20T19:45:45Z","updated_at":"2021-03-15T10:20:30Z","info":"A cozy community of streamers.","thumbnail_url":"https://static-cdn.jtvnw.net/team-profile-images/weightedblanket-profile_image-12345.png","team_name":"weightedblanket","team_display_name":"WeightedBlanket","id":"1234567"}]}`,
+		},
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&GetTeamsParams{ID: "1234567"},
+			`{"data":[{"users":[{"user_id":"278217731","user_login":"mastermndio","user_name":"MasterMndio"}],"background_image_url":"https://example.com/bg.png","banner":"https://example.com/banner.png","created_at":"2020-02-20T19:45:45Z","updated_at":"2021-03-15T10:20:30Z","info":"Team info here","thumbnail_url":"https://static-cdn.jtvnw.net/team-profile-images/test-profile.png","team_name":"testteam","team_display_name":"Test Team","id":"1234567"}]}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.GetTeams(testCase.GetTeamsParams)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be %d, got %d", testCase.statusCode, resp.StatusCode)
+		}
+
+		if resp.StatusCode == http.StatusBadRequest {
+			if resp.Error != "Bad Request" {
+				t.Errorf("expected error to be %s, got %s", "Bad Request", resp.Error)
+			}
+
+			if resp.ErrorStatus != http.StatusBadRequest {
+				t.Errorf("expected error status to be %d, got %d", http.StatusBadRequest, resp.ErrorStatus)
+			}
+
+			expectedErrMsg := "Must provide either team_id or team_name"
+			if resp.ErrorMessage != expectedErrMsg {
+				t.Errorf("expected error message to be %s, got %s", expectedErrMsg, resp.ErrorMessage)
+			}
+
+			continue
+		}
+
+		if len(resp.Data.Teams) == 0 {
+			t.Error("expected teams data but got none")
+		}
+
+		if len(resp.Data.Teams[0].Users) == 0 {
+			t.Error("expected team users but got none")
+		}
+
+		if resp.Data.Teams[0].ID == "" {
+			t.Error("expected team ID to be set")
+		}
+
+		if resp.Data.Teams[0].TeamName == "" {
+			t.Error("expected team name to be set")
+		}
+	}
+
+	// Test with HTTP Failure
+	options := &Options{
+		ClientID: "my-client-id",
+		HTTPClient: &badMockHTTPClient{
+			newMockHandler(0, "", nil),
+		},
+	}
+	c := &Client{
+		opts: options,
+		ctx:  context.Background(),
+	}
+
+	_, err := c.GetTeams(&GetTeamsParams{})
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+
+	if err.Error() != "Failed to execute API request: Oops, that's bad :(" {
+		t.Error("expected error does match return error")
+	}
+}


### PR DESCRIPTION
Added support for the [GET /teams Helix API method](https://dev.twitch.tv/docs/api/reference#get-teams) with a `GetTeams` client method.

Example Usage:

```go
client, err := helix.NewClient(&helix.Options{
    ClientID: "your-client-id",
})
if err != nil {
    // handle error
}

resp, err := client.GetTeams(&helix.GetTeamsParams{
    Name: "weightedblanket",
})
if err != nil {
    // handle error
}

fmt.Printf("%+v\n", resp)
```

Includes:

- Implementation
- Unit Test
- Docs with example usage

Let me know if anything else is needed.