### PR TITLE
fix: skip JSON decoding for responses with Content-Type: text/html

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -422,7 +422,8 @@ func (c *Client) doRequest(req *http.Request, resp *Response) error {
 		c.logf("helix: response %d %s", response.StatusCode, string(bodyBytes))
 
 		// Only attempt to decode the response if we have a response we can handle
-		if len(bodyBytes) > 0 && resp.StatusCode < http.StatusInternalServerError {
+		contentType := response.Header.Get("Content-Type")
+		if len(bodyBytes) > 0 && resp.StatusCode < http.StatusInternalServerError && !strings.Contains(contentType, "text/html") {
 			if resp.Data != nil && resp.StatusCode < http.StatusBadRequest {
 				// Successful request
 				err = json.Unmarshal(bodyBytes, &resp.Data)

--- a/helix.go
+++ b/helix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"os"
 	"reflect"
@@ -421,9 +422,12 @@ func (c *Client) doRequest(req *http.Request, resp *Response) error {
 
 		c.logf("helix: response %d %s", response.StatusCode, string(bodyBytes))
 
-		// Only attempt to decode the response if we have a response we can handle
 		contentType := response.Header.Get("Content-Type")
-		if len(bodyBytes) > 0 && resp.StatusCode < http.StatusInternalServerError && !strings.Contains(contentType, "text/html") {
+		mt, _, _ := mime.ParseMediaType(contentType)
+		isHTML := strings.EqualFold(mt, "text/html")
+
+		// Only attempt to decode the response if we have a response we can handle
+		if len(bodyBytes) > 0 && resp.StatusCode < http.StatusInternalServerError && !isHTML {
 			if resp.Data != nil && resp.StatusCode < http.StatusBadRequest {
 				// Successful request
 				err = json.Unmarshal(bodyBytes, &resp.Data)

--- a/helix_test.go
+++ b/helix_test.go
@@ -776,6 +776,44 @@ func TestDecodingBadJSON(t *testing.T) {
 	}
 }
 
+func TestHTMLResponseOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	// HTML response body with Content-Type: text/html (e.g. Cloudflare interstitial)
+	htmlBody := `<!DOCTYPE html><html><body><h1>Attention Required</h1></body></html>`
+	c := newMockClient(&Options{ClientID: "my-client-id"}, newMockHandler(http.StatusOK, htmlBody, map[string]string{
+		"Content-Type": "text/html; charset=utf-8",
+	}))
+
+	_, err := c.GetUsers(&UsersParams{
+		Logins: []string{"summit1g"},
+	})
+	if err != nil {
+		t.Errorf("expected no error for HTML response on 2xx, but got: %s", err.Error())
+	}
+}
+
+func TestHTMLResponseOnError(t *testing.T) {
+	t.Parallel()
+
+	// HTML response body with Content-Type: text/html (e.g. CDN-level 403)
+	htmlBody := `<!DOCTYPE html><html><body><h1>403 Forbidden</h1></body></html>`
+	c := newMockClient(&Options{ClientID: "my-client-id"}, newMockHandler(http.StatusForbidden, htmlBody, map[string]string{
+		"Content-Type": "text/html; charset=utf-8",
+	}))
+
+	resp, err := c.GetUsers(&UsersParams{
+		Logins: []string{"summit1g"},
+	})
+	if err != nil {
+		t.Errorf("expected no error for HTML response on 4xx, but got: %s", err.Error())
+		return
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status code %d, got %d", http.StatusForbidden, resp.StatusCode)
+	}
+}
+
 func TestGetAppAccessToken(t *testing.T) {
 	t.Parallel()
 

--- a/helix_test.go
+++ b/helix_test.go
@@ -814,6 +814,23 @@ func TestHTMLResponseOnError(t *testing.T) {
 	}
 }
 
+func TestHTMLResponseCaseInsensitiveContentType(t *testing.T) {
+	t.Parallel()
+
+	// Content-Type header values are case-insensitive per RFC 2045
+	htmlBody := `<!DOCTYPE html><html><body><h1>Attention Required</h1></body></html>`
+	c := newMockClient(&Options{ClientID: "my-client-id"}, newMockHandler(http.StatusOK, htmlBody, map[string]string{
+		"Content-Type": "Text/HTML; charset=utf-8",
+	}))
+
+	_, err := c.GetUsers(&UsersParams{
+		Logins: []string{"summit1g"},
+	})
+	if err != nil {
+		t.Errorf("expected no error for HTML response with mixed-case Content-Type, but got: %s", err.Error())
+	}
+}
+
 func TestGetAppAccessToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When Twitch's infrastructure returns an HTML response (e.g. a Cloudflare interstitial) instead of JSON, `doRequest` surfaces an opaque error: `Failed to decode API response: invalid character '<' looking for beginning of value`

This PR skips decoding when `Content-Type` is `text/html`, allowing the status code to be surfaced on the response as normal.