### PR TITLE
fix: reset error on http-request retry

### DIFF
--- a/helix.go
+++ b/helix.go
@@ -470,6 +470,11 @@ func (c *Client) doRequest(req *http.Request, resp *Response) error {
 					}
 					if refreshed {
 						tokenRefreshed = true
+						// Clear stale error state from the failed attempt so a
+						// successful retry does not appear to have failed.
+						resp.ErrorStatus = 0
+						resp.Error = ""
+						resp.ErrorMessage = ""
 						// Try again now that we have a new token
 						c.setRequestHeaders(req)
 						continue


### PR DESCRIPTION
### Problem

When an API request fails with a `401 Unauthorized` and the client successfully refreshes the token and retries the request, the retried request may return a `200 OK` with valid data, but the error is still returned. This is because the error fields (`ErrorStatus`, `Error`, `ErrorMessage`) are populated from the first failed response and are never cleared before the retry.

The following log output illustrates the issue. The first request fails with a 401, the token is refreshed, the retry succeeds with a 200 and valid data but the user still receives `status=401 error=Unauthorized message=Invalid OAuth token`:

```
helix: request GET https://api.twitch.tv/helix/eventsub/subscriptions
helix: response 401 {"error":"Unauthorized","status":401,"message":"Invalid OAuth token"}
helix: request POST https://id.twitch.tv/oauth2/token?...&grant_type=client_credentials&scope=...
helix: response 200 {"access_token":"...","expires_in":4985140,...}
helix: request GET https://api.twitch.tv/helix/eventsub/subscriptions
helix: response 200 {"total":1,"data":[...],...}
// App access token refreshed callback fires
ERROR: failed to get event sub subscriptions: status=401 error=Unauthorized message=Invalid OAuth token
```

### Root Cause

In `doRequest`, when a 401 response is received, the error body is deserialized into `resp`, setting `resp.ErrorStatus`, `resp.Error`, and `resp.ErrorMessage`. The client then refreshes the token and `continue`s the loop. On the next iteration the request succeeds and `resp.Data` is populated correctly, but nothing resets the error fields from the previous iteration. The `Response` struct ends up in a mixed state: valid data alongside a stale 401 error.